### PR TITLE
Add interfaces to make unit tests easier

### DIFF
--- a/src/B2Client.cs
+++ b/src/B2Client.cs
@@ -5,7 +5,8 @@ using B2Net.Models;
 using Newtonsoft.Json;
 
 namespace B2Net {
-	public class B2Client {
+	public class B2Client : IB2Client
+  {
 	    private B2Options _options;
 
 		public B2Client(B2Options options) {

--- a/src/B2Client.cs
+++ b/src/B2Client.cs
@@ -34,9 +34,9 @@ namespace B2Net {
 	        LargeFiles = new LargeFiles(_options);
         }
 
-		public Buckets Buckets { get; }
-	    public Files Files { get; }
-	    public LargeFiles LargeFiles { get; }
+		public IBuckets Buckets { get; }
+	    public IFiles Files { get; }
+	    public ILargeFiles LargeFiles { get; }
 
         /// <summary>
         /// Authorize against the B2 storage service. Requires that AccountId and ApplicationKey on the options object be set.

--- a/src/Buckets.cs
+++ b/src/Buckets.cs
@@ -6,7 +6,8 @@ using B2Net.Http;
 using B2Net.Models;
 
 namespace B2Net {
-	public class Buckets {
+	public class Buckets : IBuckets
+  {
 		private B2Options _options;
 	    private HttpClient _client;
 

--- a/src/Files.cs
+++ b/src/Files.cs
@@ -1,16 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using B2Net.Http;
+using B2Net.Models;
+using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using B2Net.Http;
-using B2Net.Models;
-using Newtonsoft.Json;
 
-namespace B2Net {
-	public class Files : IFiles
+namespace B2Net
+{
+  public class Files : IFiles
   {
 		private B2Options _options;
 		private HttpClient _client;

--- a/src/Files.cs
+++ b/src/Files.cs
@@ -10,7 +10,8 @@ using B2Net.Models;
 using Newtonsoft.Json;
 
 namespace B2Net {
-	public class Files {
+	public class Files : IFiles
+  {
 		private B2Options _options;
 		private HttpClient _client;
 

--- a/src/IB2Client.cs
+++ b/src/IB2Client.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using B2Net.Models;
+
+namespace B2Net
+{
+  public interface IB2Client
+  {
+    IBuckets Buckets { get; }
+    IFiles Files { get; }
+    ILargeFiles LargeFiles { get; }
+
+    Task<B2Options> Authorize(CancellationToken cancelToken = default(CancellationToken));
+  }
+}

--- a/src/IBuckets.cs
+++ b/src/IBuckets.cs
@@ -1,0 +1,17 @@
+﻿using B2Net.Models;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace B2Net
+{
+  public interface IBuckets
+  {
+    Task<B2Bucket> Create(string bucketName, B2BucketOptions options, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2Bucket> Create(string bucketName, BucketTypes bucketType, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2Bucket> Delete(string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<List<B2Bucket>> GetList(CancellationToken cancelToken = default(CancellationToken));
+    Task<B2Bucket> Update(B2BucketOptions options, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<B2Bucket> Update(BucketTypes bucketType, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+  }
+}

--- a/src/IFiles.cs
+++ b/src/IFiles.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using B2Net.Models;
+
+namespace B2Net
+{
+  public interface IFiles
+  {
+    Task<B2File> Delete(string fileId, string fileName, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> DownloadById(string fileId, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> DownloadById(string fileId, int startByte, int endByte, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> DownloadByName(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> DownloadByName(string fileName, string bucketName, int startByte, int endByte, CancellationToken cancelToken = default(CancellationToken));
+    string GetFriendlyDownloadUrl(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> GetInfo(string fileId, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2FileList> GetList(string startFileName = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<B2FileList> GetListWithPrefixOrDemiliter(string startFileName = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<B2UploadUrl> GetUploadUrl(string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<B2FileList> GetVersions(string startFileName = "", string startFileId = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<B2FileList> GetVersionsWithPrefixOrDelimiter(string startFileName = "", string startFileId = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> Hide(string fileName, string bucketId = "", string fileId = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> Upload(byte[] fileData, string fileName, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, bool autoRetry, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
+  }
+}

--- a/src/ILargeFiles.cs
+++ b/src/ILargeFiles.cs
@@ -1,0 +1,18 @@
+﻿using B2Net.Models;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace B2Net
+{
+  public interface ILargeFiles
+  {
+    Task<B2CancelledFile> CancelLargeFile(string fileId, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> FinishLargeFile(string fileId, string[] partSHA1Array, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2UploadPartUrl> GetUploadPartUrl(string fileId, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2IncompleteLargeFiles> ListIncompleteFiles(string bucketId, string startFileId = "", string maxFileCount = "", CancellationToken cancelToken = default(CancellationToken));
+    Task<B2LargeFileParts> ListPartsForIncompleteFile(string fileId, int startPartNumber, int maxPartCount, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2File> StartLargeFile(string fileName, string contentType = "", string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
+    Task<B2UploadPart> UploadPart(byte[] fileData, int partNumber, B2UploadPartUrl uploadPartUrl, CancellationToken cancelToken = default(CancellationToken));
+  }
+}

--- a/src/LargeFiles.cs
+++ b/src/LargeFiles.cs
@@ -10,7 +10,8 @@ using B2Net.Models;
 using Newtonsoft.Json;
 
 namespace B2Net {
-	public class LargeFiles {
+	public class LargeFiles : ILargeFiles
+  {
 		private B2Options _options;
 		private HttpClient _client;
 

--- a/src/LargeFiles.cs
+++ b/src/LargeFiles.cs
@@ -1,16 +1,14 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Net;
+﻿using B2Net.Http;
+using B2Net.Http.RequestGenerators;
+using B2Net.Models;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using B2Net.Http;
-using B2Net.Http.RequestGenerators;
-using B2Net.Models;
-using Newtonsoft.Json;
 
-namespace B2Net {
-	public class LargeFiles : ILargeFiles
+namespace B2Net
+{
+  public class LargeFiles : ILargeFiles
   {
 		private B2Options _options;
 		private HttpClient _client;


### PR DESCRIPTION
I would like to use your great library in a project of mine, but I've been having issues integrating it my unit tests.

I've added interfaces to your classes to make it easier to inject mock objects representing B2.Net into third party test code.