### PR TITLE
Support for Application Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ var client = new B2Client("ACCOUNTID", "APPLICATIONKEY");
 var options = await client.Authorize();
 ```
 
+### Application Keys
+
+[Fine grained application keys](https://www.backblaze.com/b2/docs/application_keys.html) allow you to specify access to specific
+capabilities and/or buckets.
+
+To authorize using one of these application keys, you must provide the generated application key and it's specific id, and set them
+on the `B2Options` object:
+
+```csharp
+var options = new B2Options {
+	ApplcationKey = "YOUR GENERATED APPLICATION KEY",
+	ApplcationKeyId = "YOUR GENERATED APPLICATION KEY ID"
+};
+var client = new B2Client(options);
+```
+
+Note you do **not** to specify your master **AccountId**.
+
 ### <a name="buckets"></a>Buckets
 #### List Buckets
 ```csharp

--- a/src/Http/RequestGenerators/AuthRequestGenerator.cs
+++ b/src/Http/RequestGenerators/AuthRequestGenerator.cs
@@ -15,9 +15,9 @@ namespace B2Net.Http {
 				RequestUri = uri
 			};
 
-      var accountId = !string.IsNullOrWhiteSpace(options.ApplicationKeyId)
-        ? options.ApplicationKeyId
-        : options.AccountId;
+			var accountId = !string.IsNullOrWhiteSpace(options.ApplicationKeyId)
+				? options.ApplicationKeyId
+				: options.AccountId;
 
 			request.Headers.Add("Authorization", Utilities.CreateAuthorizationHeader(accountId, options.ApplicationKey));
 

--- a/src/Http/RequestGenerators/AuthRequestGenerator.cs
+++ b/src/Http/RequestGenerators/AuthRequestGenerator.cs
@@ -15,7 +15,11 @@ namespace B2Net.Http {
 				RequestUri = uri
 			};
 
-			request.Headers.Add("Authorization", Utilities.CreateAuthorizationHeader(options.AccountId, options.ApplicationKey));
+      var accountId = !string.IsNullOrWhiteSpace(options.ApplicationKeyId)
+        ? options.ApplicationKeyId
+        : options.AccountId;
+
+			request.Headers.Add("Authorization", Utilities.CreateAuthorizationHeader(accountId, options.ApplicationKey));
 
 			return request;
 		}

--- a/src/Models/B2AuthAllowedResponse.cs
+++ b/src/Models/B2AuthAllowedResponse.cs
@@ -1,7 +1,7 @@
 ﻿namespace B2Net.Models
 {
-  public class B2AuthAllowedResponse
-  {
-    public string bucketId { get; set; }
-  }
+	public class B2AuthAllowedResponse
+	{
+		public string bucketId { get; set; }
+	}
 }

--- a/src/Models/B2AuthAllowedResponse.cs
+++ b/src/Models/B2AuthAllowedResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace B2Net.Models
+{
+  public class B2AuthAllowedResponse
+  {
+    public string bucketId { get; set; }
+  }
+}

--- a/src/Models/B2AuthResponse.cs
+++ b/src/Models/B2AuthResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace B2Net.Models {
 	public class B2AuthResponse {
-    public B2AuthAllowedResponse allowed { get; set; }
+		public B2AuthAllowedResponse allowed { get; set; }
 		public string accountId { get; set; }
 		public string apiUrl { get; set; }
 		public string authorizationToken { get; set; }

--- a/src/Models/B2AuthResponse.cs
+++ b/src/Models/B2AuthResponse.cs
@@ -1,5 +1,6 @@
 ﻿namespace B2Net.Models {
 	public class B2AuthResponse {
+    public B2AuthAllowedResponse allowed { get; set; }
 		public string accountId { get; set; }
 		public string apiUrl { get; set; }
 		public string authorizationToken { get; set; }

--- a/src/Models/B2Options.cs
+++ b/src/Models/B2Options.cs
@@ -42,6 +42,12 @@
             RecommendedPartSize = response.recommendedPartSize;
             AbsoluteMinimumPartSize = response.absoluteMinimumPartSize;
             MinimumPartSize = response.minimumPartSize;
+
+      if (!string.IsNullOrWhiteSpace(response.allowed?.bucketId))
+      {
+        BucketId = response.allowed.bucketId;
+        PersistBucket = true;
+      }
 		}
 	}
 }

--- a/src/Models/B2Options.cs
+++ b/src/Models/B2Options.cs
@@ -2,7 +2,7 @@
 	public class B2Options {
 		public string AccountId { get; set; }
 		public string ApplicationKey { get; set; }
-    public string ApplicationKeyId { get; set; }
+		public string ApplicationKeyId { get; set; }
 		public string BucketId { get; set; }
 		/// <summary>
 		/// Setting this to true will use this bucket by default for all
@@ -31,10 +31,10 @@
         }
 
 		public void SetState(B2AuthResponse response) {
-      if (string.IsNullOrWhiteSpace(AccountId))
-      {
-        AccountId = response.accountId;
-      }
+			if (string.IsNullOrWhiteSpace(AccountId))
+			{
+				AccountId = response.accountId;
+			}
 
 			ApiUrl = response.apiUrl;
 			DownloadUrl = response.downloadUrl;
@@ -43,11 +43,11 @@
             AbsoluteMinimumPartSize = response.absoluteMinimumPartSize;
             MinimumPartSize = response.minimumPartSize;
 
-      if (!string.IsNullOrWhiteSpace(response.allowed?.bucketId))
-      {
-        BucketId = response.allowed.bucketId;
-        PersistBucket = true;
-      }
+			if (!string.IsNullOrWhiteSpace(response.allowed?.bucketId))
+			{
+				BucketId = response.allowed.bucketId;
+				PersistBucket = true;
+			}
 		}
 	}
 }

--- a/src/Models/B2Options.cs
+++ b/src/Models/B2Options.cs
@@ -2,6 +2,7 @@
 	public class B2Options {
 		public string AccountId { get; set; }
 		public string ApplicationKey { get; set; }
+    public string ApplicationKeyId { get; set; }
 		public string BucketId { get; set; }
 		/// <summary>
 		/// Setting this to true will use this bucket by default for all
@@ -30,6 +31,11 @@
         }
 
 		public void SetState(B2AuthResponse response) {
+      if (string.IsNullOrWhiteSpace(AccountId))
+      {
+        AccountId = response.accountId;
+      }
+
 			ApiUrl = response.apiUrl;
 			DownloadUrl = response.downloadUrl;
 			AuthorizationToken = response.authorizationToken;


### PR DESCRIPTION
I tried to use the new application keys system (https://www.backblaze.com/b2/docs/application_keys.html) but found that authorization was failing.

It appears that B2 wants you to auth using the ID of the key, and not the account ID.
Each request after that though wants you to use the account ID.

I've added a new property to `B2Options` for the `ApplicationKeyId`.
If this is set, authorization will use this instead of the `AccountId`.
If `AccountId` is not set at all, then it will be set based on the response.

I've also added new properties for the authorization response, which will specify the allowed bucket ID if the auth key only has access to a single bucket.
If this is present, it sets the `PersistBucket` flag and the `BucketId`.

