### PR TITLE
Reformat all code using editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,24 @@
 # EditorConfig is awesome: https://EditorConfig.org
 
+###############################
+# Core EditorConfig Options   #
+###############################
+
 root = true
 
+# All files
 [*]
 indent_style = tab
+
+# Code files
+[*.{cs,csx,vb,vbx}]
 indent_size = 4
+insert_final_newline = true
+
+
+###############################
+# .NET Coding Conventions     #
+###############################
+
+[*.{cs,vb}]
+csharp_new_line_before_open_brace = none

--- a/src/B2Client.cs
+++ b/src/B2Client.cs
@@ -1,21 +1,19 @@
-﻿using System;
+﻿using B2Net.Http;
+using B2Net.Models;
+using Newtonsoft.Json;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using B2Net.Http;
-using B2Net.Models;
-using Newtonsoft.Json;
 
 namespace B2Net {
-	public class B2Client : IB2Client
-  {
-	    private B2Options _options;
+	public class B2Client : IB2Client {
+		private B2Options _options;
 
 		public B2Client(B2Options options) {
 			_options = options;
 			Buckets = new Buckets(options);
 			Files = new Files(options);
-            LargeFiles = new LargeFiles(options);
+			LargeFiles = new LargeFiles(options);
 		}
 
 		/// <summary>
@@ -25,82 +23,84 @@ namespace B2Net {
 		/// <param name="applicationkey"></param>
 		/// <param name="requestTimeout"></param>
 		public B2Client(string accountId, string applicationkey, int requestTimeout = 100) {
-	        _options = new B2Options() {
-	            AccountId = accountId,
-                ApplicationKey = applicationkey,
+			_options = new B2Options() {
+				AccountId = accountId,
+				ApplicationKey = applicationkey,
 				RequestTimeout = requestTimeout
-	        };
-            _options = Authorize(_options);
+			};
+			_options = Authorize(_options);
 
-            Buckets = new Buckets(_options);
-	        Files = new Files(_options);
-	        LargeFiles = new LargeFiles(_options);
-        }
+			Buckets = new Buckets(_options);
+			Files = new Files(_options);
+			LargeFiles = new LargeFiles(_options);
+		}
 
-	  /// <summary>
-	  /// Simple method for instantiating the B2Client. Does auth for you. See https://www.backblaze.com/b2/docs/application_keys.html for details on application keys.
-	  /// </summary>
-	  /// <param name="accountId"></param>
-	  /// <param name="applicationkey"></param>
-	  /// <param name="requestTimeout"></param>
-	  public B2Client(string accountId, string applicationkey, string keyId, int requestTimeout = 100) {
-		  _options = new B2Options() {
-			  AccountId = accountId,
-			  KeyId = keyId,
-			  ApplicationKey = applicationkey,
-			  RequestTimeout = requestTimeout
-		  };
-		  _options = Authorize(_options);
+		/// <summary>
+		/// Simple method for instantiating the B2Client. Does auth for you. See https://www.backblaze.com/b2/docs/application_keys.html for details on application keys.
+		/// </summary>
+		/// <param name="accountId"></param>
+		/// <param name="applicationkey"></param>
+		/// <param name="requestTimeout"></param>
+		public B2Client(string accountId, string applicationkey, string keyId, int requestTimeout = 100) {
+			_options = new B2Options() {
+				AccountId = accountId,
+				KeyId = keyId,
+				ApplicationKey = applicationkey,
+				RequestTimeout = requestTimeout
+			};
+			_options = Authorize(_options);
 
-		  Buckets = new Buckets(_options);
-		  Files = new Files(_options);
-		  LargeFiles = new LargeFiles(_options);
-	  }
+			Buckets = new Buckets(_options);
+			Files = new Files(_options);
+			LargeFiles = new LargeFiles(_options);
+		}
 
 		public IBuckets Buckets { get; }
-	    public IFiles Files { get; }
-	    public ILargeFiles LargeFiles { get; }
+		public IFiles Files { get; }
+		public ILargeFiles LargeFiles { get; }
 
-        /// <summary>
-        /// Authorize against the B2 storage service. Requires that AccountId and ApplicationKey on the options object be set.
-        /// </summary>
-        /// <returns>B2Options containing the download url, new api url, and authorization token.</returns>
-        public async Task<B2Options> Authorize(CancellationToken cancelToken = default(CancellationToken)) {
-	        return Authorize(_options);
-        }
+		/// <summary>
+		/// Authorize against the B2 storage service. Requires that AccountId and ApplicationKey on the options object be set.
+		/// </summary>
+		/// <returns>B2Options containing the download url, new api url, and authorization token.</returns>
+		public async Task<B2Options> Authorize(CancellationToken cancelToken = default(CancellationToken)) {
+			return Authorize(_options);
+		}
 
-	    public static B2Options Authorize(string accountId, string applicationkey, string keyId = "") {
-	        return Authorize(new B2Options() {AccountId = accountId, ApplicationKey = applicationkey, KeyId = keyId});
-	    }
+		public static B2Options Authorize(string accountId, string applicationkey, string keyId = "") {
+			return Authorize(new B2Options() { AccountId = accountId, ApplicationKey = applicationkey, KeyId = keyId });
+		}
 
-        /// <summary>
-        /// Requires that AccountId and ApplicationKey on the options object be set. If you are using an application key you must specify the accountId, the keyId, and the applicationKey.
-        /// </summary>
-        /// <param name="options"></param>
-        /// <returns></returns>
-	    public static B2Options Authorize(B2Options options) {
-            var client = HttpClientFactory.CreateHttpClient(options.RequestTimeout);
+		/// <summary>
+		/// Requires that AccountId and ApplicationKey on the options object be set. If you are using an application key you must specify the accountId, the keyId, and the applicationKey.
+		/// </summary>
+		/// <param name="options"></param>
+		/// <returns></returns>
+		public static B2Options Authorize(B2Options options) {
+			var client = HttpClientFactory.CreateHttpClient(options.RequestTimeout);
 
-	        if (!string.IsNullOrEmpty(options.KeyId) && string.IsNullOrEmpty(options.AccountId)) {
-		        throw new AuthorizationException("You supplied an application keyid, but not the accountid. Both are required if you are not using a master key.");
-	        }
+			if (!string.IsNullOrEmpty(options.KeyId) && string.IsNullOrEmpty(options.AccountId)) {
+				throw new AuthorizationException("You supplied an application keyid, but not the accountid. Both are required if you are not using a master key.");
+			}
 
-            var requestMessage = AuthRequestGenerator.Authorize(options);
-            var response = client.SendAsync(requestMessage).Result;
+			var requestMessage = AuthRequestGenerator.Authorize(options);
+			var response = client.SendAsync(requestMessage).Result;
 
-            var jsonResponse = response.Content.ReadAsStringAsync().Result;
-            if (response.IsSuccessStatusCode) {
-                var authResponse = JsonConvert.DeserializeObject<B2AuthResponse>(jsonResponse);
+			var jsonResponse = response.Content.ReadAsStringAsync().Result;
+			if (response.IsSuccessStatusCode) {
+				var authResponse = JsonConvert.DeserializeObject<B2AuthResponse>(jsonResponse);
 
-                options.SetState(authResponse);
-            } else if (response.StatusCode == HttpStatusCode.Unauthorized) {
-	            // Return a better exception because of confusing Keys api.
+				options.SetState(authResponse);
+			}
+			else if (response.StatusCode == HttpStatusCode.Unauthorized) {
+				// Return a better exception because of confusing Keys api.
 				throw new AuthorizationException("If you are using an Application key and not a Master key, make sure that you are supplying the Key ID and Key Value for that Application Key. Do not mix your Account ID with your Application Key.");
-            } else {
-                throw new AuthorizationException(jsonResponse);
-            }
+			}
+			else {
+				throw new AuthorizationException(jsonResponse);
+			}
 
-	        return options;
-        }
+			return options;
+		}
 	}
 }

--- a/src/B2Net.sln
+++ b/src/B2Net.sln
@@ -6,6 +6,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "B2Net", "B2Net.csproj", "{E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "B2NET.Tests", "..\tests\B2NET.Tests.csproj", "{05FA55C0-D0C4-4CB4-B6C9-A55B8F26311F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{90326E2D-DC64-41D2-A601-8C098431A5E0}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Buckets.cs
+++ b/src/Buckets.cs
@@ -6,16 +6,15 @@ using B2Net.Http;
 using B2Net.Models;
 
 namespace B2Net {
-	public class Buckets : IBuckets
-  {
+	public class Buckets : IBuckets {
 		private B2Options _options;
-	    private HttpClient _client;
+		private HttpClient _client;
 		private string _api = "Buckets";
 
-        public Buckets(B2Options options) {
+		public Buckets(B2Options options) {
 			_options = options;
-            _client = HttpClientFactory.CreateHttpClient(options.RequestTimeout);
-        }
+			_client = HttpClientFactory.CreateHttpClient(options.RequestTimeout);
+		}
 
 		public async Task<List<B2Bucket>> GetList(CancellationToken cancelToken = default(CancellationToken)) {
 			var requestMessage = BucketRequestGenerators.GetBucketList(_options);
@@ -25,84 +24,81 @@ namespace B2Net {
 			return bucketList.Buckets;
 		}
 
-	    /// <summary>
-	    /// Creates a new bucket. A bucket belongs to the account used to create it. If BucketType is not set allPrivate will be used by default.
-	    /// </summary>
-	    /// <param name="bucketName"></param>
-	    /// <param name="bucketType"></param>
-	    /// <param name="cancelToken"></param>
-	    /// <returns></returns>
-	    public async Task<B2Bucket> Create(string bucketName, BucketTypes bucketType,
-	        CancellationToken cancelToken = default(CancellationToken)) {
-	        var requestMessage = BucketRequestGenerators.CreateBucket(_options, bucketName, bucketType.ToString());
-	        var response = await _client.SendAsync(requestMessage, cancelToken);
+		/// <summary>
+		/// Creates a new bucket. A bucket belongs to the account used to create it. If BucketType is not set allPrivate will be used by default.
+		/// </summary>
+		/// <param name="bucketName"></param>
+		/// <param name="bucketType"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2Bucket> Create(string bucketName, BucketTypes bucketType,
+			CancellationToken cancelToken = default(CancellationToken)) {
+			var requestMessage = BucketRequestGenerators.CreateBucket(_options, bucketName, bucketType.ToString());
+			var response = await _client.SendAsync(requestMessage, cancelToken);
 
-	        return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
-	    }
+			return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
+		}
 
-	    /// <summary>
-        /// Creates a new bucket. A bucket belongs to the account used to create it. If BucketType is not set allPrivate will be used by default.
-        /// Use this method to set Cache-Control.
-        /// </summary>
-        /// <param name="bucketName"></param>
-        /// <param name="bucketType"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2Bucket> Create(string bucketName, B2BucketOptions options, CancellationToken cancelToken = default(CancellationToken))
-        {
-            var requestMessage = BucketRequestGenerators.CreateBucket(_options, bucketName, options);
-            var response = await _client.SendAsync(requestMessage, cancelToken);
+		/// <summary>
+		/// Creates a new bucket. A bucket belongs to the account used to create it. If BucketType is not set allPrivate will be used by default.
+		/// Use this method to set Cache-Control.
+		/// </summary>
+		/// <param name="bucketName"></param>
+		/// <param name="bucketType"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2Bucket> Create(string bucketName, B2BucketOptions options, CancellationToken cancelToken = default(CancellationToken)) {
+			var requestMessage = BucketRequestGenerators.CreateBucket(_options, bucketName, options);
+			var response = await _client.SendAsync(requestMessage, cancelToken);
 
-            return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
-        }
+			return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
+		}
 
-        /// <summary>
-        /// Deletes the bucket specified. Only buckets that contain no version of any files can be deleted.
-        /// </summary>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2Bucket> Delete(string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
+		/// <summary>
+		/// Deletes the bucket specified. Only buckets that contain no version of any files can be deleted.
+		/// </summary>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2Bucket> Delete(string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
 			var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
-            
+
 			var requestMessage = BucketRequestGenerators.DeleteBucket(_options, operationalBucketId);
 			var response = await _client.SendAsync(requestMessage, cancelToken);
 
 			return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
-        }
+		}
 
-        /// <summary>
-        /// Update an existing bucket. bucketId is only optional if you are persisting a bucket for this client.
-        /// </summary>
-        /// <param name="bucketType"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2Bucket> Update(BucketTypes bucketType, string bucketId = "", CancellationToken cancelToken = default(CancellationToken))
-        {
-            var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
-            var requestMessage = BucketRequestGenerators.UpdateBucket(_options, operationalBucketId, bucketType.ToString());
-            var response = await _client.SendAsync(requestMessage, cancelToken);
+		/// <summary>
+		/// Update an existing bucket. bucketId is only optional if you are persisting a bucket for this client.
+		/// </summary>
+		/// <param name="bucketType"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2Bucket> Update(BucketTypes bucketType, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
+			var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
+			var requestMessage = BucketRequestGenerators.UpdateBucket(_options, operationalBucketId, bucketType.ToString());
+			var response = await _client.SendAsync(requestMessage, cancelToken);
 
-            return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
-        }
+			return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
+		}
 
-        /// <summary>
-        /// Update an existing bucket. bucketId is only optional if you are persisting a bucket for this client.
-        /// Use this method to set Cache-Control.
-        /// </summary>
-        /// <param name="bucketType"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2Bucket> Update(B2BucketOptions options, string bucketId = "", CancellationToken cancelToken = default(CancellationToken))
-        {
-            var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
+		/// <summary>
+		/// Update an existing bucket. bucketId is only optional if you are persisting a bucket for this client.
+		/// Use this method to set Cache-Control.
+		/// </summary>
+		/// <param name="bucketType"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2Bucket> Update(B2BucketOptions options, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
+			var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
 
-            var requestMessage = BucketRequestGenerators.UpdateBucket(_options, operationalBucketId, options);
-            var response = await _client.SendAsync(requestMessage, cancelToken);
+			var requestMessage = BucketRequestGenerators.UpdateBucket(_options, operationalBucketId, options);
+			var response = await _client.SendAsync(requestMessage, cancelToken);
 
-            return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
-        }
-    }
+			return await ResponseParser.ParseResponse<B2Bucket>(response, _api);
+		}
+	}
 }

--- a/src/Files.cs
+++ b/src/Files.cs
@@ -8,14 +8,12 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace B2Net
-{
-  public class Files : IFiles
-  {
+namespace B2Net {
+	public class Files : IFiles {
 		private B2Options _options;
 		private HttpClient _client;
-	  private string _api = "Files";
-		
+		private string _api = "Files";
+
 		public Files(B2Options options) {
 			_options = options;
 			_client = HttpClientFactory.CreateHttpClient(options.RequestTimeout);
@@ -30,202 +28,202 @@ namespace B2Net
 		/// <param name="cancelToken"></param>
 		/// <returns></returns>
 		public async Task<B2FileList> GetList(string startFileName = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
-		    return await GetListWithPrefixOrDemiliter(startFileName, "", "", maxFileCount, bucketId, cancelToken);
+			return await GetListWithPrefixOrDemiliter(startFileName, "", "", maxFileCount, bucketId, cancelToken);
 		}
 
-        /// <summary>
-        /// BETA: Lists the names of all non-hidden files in a bucket, starting at a given name. With an optional file prefix or delimiter.
-        /// See here for more details: https://www.backblaze.com/b2/docs/b2_list_file_names.html
-        /// </summary>
-        /// <param name="startFileName"></param>
-        /// <param name="prefix"></param>
-        /// <param name="delimiter"></param>
-        /// <param name="maxFileCount"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-	    public async Task<B2FileList> GetListWithPrefixOrDemiliter(string startFileName = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
-	        var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
+		/// <summary>
+		/// BETA: Lists the names of all non-hidden files in a bucket, starting at a given name. With an optional file prefix or delimiter.
+		/// See here for more details: https://www.backblaze.com/b2/docs/b2_list_file_names.html
+		/// </summary>
+		/// <param name="startFileName"></param>
+		/// <param name="prefix"></param>
+		/// <param name="delimiter"></param>
+		/// <param name="maxFileCount"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2FileList> GetListWithPrefixOrDemiliter(string startFileName = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
+			var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
 
-	        var requestMessage = FileMetaDataRequestGenerators.GetList(_options, operationalBucketId, startFileName, maxFileCount, prefix, delimiter);
-	        var response = await _client.SendAsync(requestMessage, cancelToken);
+			var requestMessage = FileMetaDataRequestGenerators.GetList(_options, operationalBucketId, startFileName, maxFileCount, prefix, delimiter);
+			var response = await _client.SendAsync(requestMessage, cancelToken);
 
-	        return await ResponseParser.ParseResponse<B2FileList>(response, _api);
-	    }
+			return await ResponseParser.ParseResponse<B2FileList>(response, _api);
+		}
 
-        /// <summary>
-        /// Lists all of the versions of all of the files contained in one bucket,
-        /// in alphabetical order by file name, and by reverse of date/time uploaded
-        /// for versions of files with the same name.
-        /// </summary>
-        /// <param name="startFileName"></param>
-        /// <param name="startFileId"></param>
-        /// <param name="maxFileCount"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2FileList> GetVersions(string startFileName = "", string startFileId = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
-            return await GetVersionsWithPrefixOrDelimiter(startFileName, startFileId, "", "", maxFileCount, bucketId, cancelToken);
-        }
+		/// <summary>
+		/// Lists all of the versions of all of the files contained in one bucket,
+		/// in alphabetical order by file name, and by reverse of date/time uploaded
+		/// for versions of files with the same name.
+		/// </summary>
+		/// <param name="startFileName"></param>
+		/// <param name="startFileId"></param>
+		/// <param name="maxFileCount"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2FileList> GetVersions(string startFileName = "", string startFileId = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
+			return await GetVersionsWithPrefixOrDelimiter(startFileName, startFileId, "", "", maxFileCount, bucketId, cancelToken);
+		}
 
-        /// <summary>
-        /// BETA: Lists all of the versions of all of the files contained in one bucket,
-        /// in alphabetical order by file name, and by reverse of date/time uploaded
-        /// for versions of files with the same name. With an optional file prefix or delimiter.
-        /// See here for more details: https://www.backblaze.com/b2/docs/b2_list_file_versions.html
-        /// </summary>
-        /// <param name="startFileName"></param>
-        /// <param name="startFileId"></param>
-        /// <param name="prefix"></param>
-        /// <param name="delimiter"></param>
-        /// <param name="maxFileCount"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-	    public async Task<B2FileList> GetVersionsWithPrefixOrDelimiter(string startFileName = "", string startFileId = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
-	        var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
+		/// <summary>
+		/// BETA: Lists all of the versions of all of the files contained in one bucket,
+		/// in alphabetical order by file name, and by reverse of date/time uploaded
+		/// for versions of files with the same name. With an optional file prefix or delimiter.
+		/// See here for more details: https://www.backblaze.com/b2/docs/b2_list_file_versions.html
+		/// </summary>
+		/// <param name="startFileName"></param>
+		/// <param name="startFileId"></param>
+		/// <param name="prefix"></param>
+		/// <param name="delimiter"></param>
+		/// <param name="maxFileCount"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2FileList> GetVersionsWithPrefixOrDelimiter(string startFileName = "", string startFileId = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
+			var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
 
-	        var requestMessage = FileMetaDataRequestGenerators.ListVersions(_options, operationalBucketId, startFileName, startFileId, maxFileCount, prefix, delimiter);
-	        var response = await _client.SendAsync(requestMessage, cancelToken);
+			var requestMessage = FileMetaDataRequestGenerators.ListVersions(_options, operationalBucketId, startFileName, startFileId, maxFileCount, prefix, delimiter);
+			var response = await _client.SendAsync(requestMessage, cancelToken);
 
-	        return await ResponseParser.ParseResponse<B2FileList>(response, _api);
-	    }
+			return await ResponseParser.ParseResponse<B2FileList>(response, _api);
+		}
 
-        /// <summary>
-        /// Gets information about one file stored in B2.
-        /// </summary>
-        /// <param name="fileId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2File> GetInfo(string fileId, CancellationToken cancelToken = default(CancellationToken)) {
+		/// <summary>
+		/// Gets information about one file stored in B2.
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> GetInfo(string fileId, CancellationToken cancelToken = default(CancellationToken)) {
 			var requestMessage = FileMetaDataRequestGenerators.GetInfo(_options, fileId);
 			var response = await _client.SendAsync(requestMessage, cancelToken);
 
 			return await ResponseParser.ParseResponse<B2File>(response, _api);
-        }
+		}
 
-        /// <summary>
-        /// get an upload url for use with one Thread.
-        /// </summary>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2UploadUrl> GetUploadUrl(string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
-            var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
+		/// <summary>
+		/// get an upload url for use with one Thread.
+		/// </summary>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2UploadUrl> GetUploadUrl(string bucketId = "", CancellationToken cancelToken = default(CancellationToken)) {
+			var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
 
-            // send the request.
-            var uploadUrlRequest = FileUploadRequestGenerators.GetUploadUrl(_options, operationalBucketId);
-            var uploadUrlResponse = await _client.SendAsync(uploadUrlRequest, cancelToken);
+			// send the request.
+			var uploadUrlRequest = FileUploadRequestGenerators.GetUploadUrl(_options, operationalBucketId);
+			var uploadUrlResponse = await _client.SendAsync(uploadUrlRequest, cancelToken);
 
-            // parse response and return it.
-            var uploadUrl = await ResponseParser.ParseResponse<B2UploadUrl>(uploadUrlResponse);
+			// parse response and return it.
+			var uploadUrl = await ResponseParser.ParseResponse<B2UploadUrl>(uploadUrlResponse);
 
-            // Set the upload auth token
-            _options.UploadAuthorizationToken = uploadUrl.AuthorizationToken;
+			// Set the upload auth token
+			_options.UploadAuthorizationToken = uploadUrl.AuthorizationToken;
 
-            return uploadUrl;
-        }
+			return uploadUrl;
+		}
 
-        /// <summary>
-        /// DEPRECATED: This method has been deprecated in favor of the Upload that takes an UploadUrl parameter.
-        /// The other Upload method is the preferred, and more efficient way, of uploading to B2.
-        /// </summary>
-        /// <param name="fileData"></param>
-        /// <param name="fileName"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2File> Upload(byte[] fileData, string fileName, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken)) {
-            var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
+		/// <summary>
+		/// DEPRECATED: This method has been deprecated in favor of the Upload that takes an UploadUrl parameter.
+		/// The other Upload method is the preferred, and more efficient way, of uploading to B2.
+		/// </summary>
+		/// <param name="fileData"></param>
+		/// <param name="fileName"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> Upload(byte[] fileData, string fileName, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken)) {
+			var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
 
-            // Get the upload url for this file
-            var uploadUrlRequest = FileUploadRequestGenerators.GetUploadUrl(_options, operationalBucketId);
-            var uploadUrlResponse = _client.SendAsync(uploadUrlRequest, cancelToken).Result;
-            var uploadUrlData = await uploadUrlResponse.Content.ReadAsStringAsync();
-            var uploadUrlObject = JsonConvert.DeserializeObject<B2UploadUrl>(uploadUrlData);
-            // Set the upload auth token
-            _options.UploadAuthorizationToken = uploadUrlObject.AuthorizationToken;
+			// Get the upload url for this file
+			var uploadUrlRequest = FileUploadRequestGenerators.GetUploadUrl(_options, operationalBucketId);
+			var uploadUrlResponse = _client.SendAsync(uploadUrlRequest, cancelToken).Result;
+			var uploadUrlData = await uploadUrlResponse.Content.ReadAsStringAsync();
+			var uploadUrlObject = JsonConvert.DeserializeObject<B2UploadUrl>(uploadUrlData);
+			// Set the upload auth token
+			_options.UploadAuthorizationToken = uploadUrlObject.AuthorizationToken;
 
-            // Now we can upload the file
-            var requestMessage = FileUploadRequestGenerators.Upload(_options, uploadUrlObject.UploadUrl, fileData, fileName, fileInfo);
-            var response = await _client.SendAsync(requestMessage, cancelToken);
+			// Now we can upload the file
+			var requestMessage = FileUploadRequestGenerators.Upload(_options, uploadUrlObject.UploadUrl, fileData, fileName, fileInfo);
+			var response = await _client.SendAsync(requestMessage, cancelToken);
 
-            return await ResponseParser.ParseResponse<B2File>(response, _api);
-        }
+			return await ResponseParser.ParseResponse<B2File>(response, _api);
+		}
 
-        /// <summary>
-        /// Uploads one file to B2, returning its unique file ID. Filename will be URL Encoded.
-        /// </summary>
-        /// <param name="fileData"></param>
-        /// <param name="fileName"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken)) {
-            return await Upload(fileData, fileName, uploadUrl, false, bucketId, fileInfo, cancelToken);
-        }
+		/// <summary>
+		/// Uploads one file to B2, returning its unique file ID. Filename will be URL Encoded.
+		/// </summary>
+		/// <param name="fileData"></param>
+		/// <param name="fileName"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken)) {
+			return await Upload(fileData, fileName, uploadUrl, false, bucketId, fileInfo, cancelToken);
+		}
 
-        /// <summary>
-        /// Uploads one file to B2, returning its unique file ID. Filename will be URL Encoded. If auto retry
-        /// is set true it will retry a failed upload once after 1 second.
-        /// </summary>
-        /// <param name="fileData"></param>
-        /// <param name="fileName"></param>
-        /// <param name="uploadUrl"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="autoRetry">Retry a failed upload one time after waiting for 1 second.</param>
-        /// <param name="fileInfo"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-	    public async Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, bool autoRetry, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken)) {
-	        // Now we can upload the file
-	        var requestMessage = FileUploadRequestGenerators.Upload(_options, uploadUrl.UploadUrl, fileData, fileName, fileInfo);
+		/// <summary>
+		/// Uploads one file to B2, returning its unique file ID. Filename will be URL Encoded. If auto retry
+		/// is set true it will retry a failed upload once after 1 second.
+		/// </summary>
+		/// <param name="fileData"></param>
+		/// <param name="fileName"></param>
+		/// <param name="uploadUrl"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="autoRetry">Retry a failed upload one time after waiting for 1 second.</param>
+		/// <param name="fileInfo"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, bool autoRetry, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken)) {
+			// Now we can upload the file
+			var requestMessage = FileUploadRequestGenerators.Upload(_options, uploadUrl.UploadUrl, fileData, fileName, fileInfo);
 
-	        var response = await _client.SendAsync(requestMessage, cancelToken);
-            // Auto retry
-            if (autoRetry && (
-                    response.StatusCode == (HttpStatusCode)429 ||
-                    response.StatusCode == HttpStatusCode.RequestTimeout ||
-                    response.StatusCode == HttpStatusCode.ServiceUnavailable)) {
-                Task.Delay(1000, cancelToken).Wait(cancelToken);
-                response = await _client.SendAsync(requestMessage, cancelToken);
-            }
+			var response = await _client.SendAsync(requestMessage, cancelToken);
+			// Auto retry
+			if (autoRetry && (
+			response.StatusCode == (HttpStatusCode)429 ||
+			response.StatusCode == HttpStatusCode.RequestTimeout ||
+			response.StatusCode == HttpStatusCode.ServiceUnavailable)) {
+				Task.Delay(1000, cancelToken).Wait(cancelToken);
+				response = await _client.SendAsync(requestMessage, cancelToken);
+			}
 
-	        return await ResponseParser.ParseResponse<B2File>(response, _api);
-	    }
+			return await ResponseParser.ParseResponse<B2File>(response, _api);
+		}
 
-        /// <summary>
-        /// Downloads a file part by providing the name of the bucket and the name and byte range of the file.
-        /// For use with the Larg File API.
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="bucketName"></param>
-        /// <param name="startBytes"></param>
-        /// <param name="endBytes"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-	    public async Task<B2File> DownloadByName(string fileName, string bucketName, int startByte, int endByte,
-	        CancellationToken cancelToken = default(CancellationToken)) {
-            // Are we searching by name or id?
-            HttpRequestMessage request;
-            request = FileDownloadRequestGenerators.DownloadByName(_options, bucketName, fileName, $"{startByte}-{endByte}");
+		/// <summary>
+		/// Downloads a file part by providing the name of the bucket and the name and byte range of the file.
+		/// For use with the Larg File API.
+		/// </summary>
+		/// <param name="fileName"></param>
+		/// <param name="bucketName"></param>
+		/// <param name="startBytes"></param>
+		/// <param name="endBytes"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> DownloadByName(string fileName, string bucketName, int startByte, int endByte,
+		CancellationToken cancelToken = default(CancellationToken)) {
+			// Are we searching by name or id?
+			HttpRequestMessage request;
+			request = FileDownloadRequestGenerators.DownloadByName(_options, bucketName, fileName, $"{startByte}-{endByte}");
 
-            // Send the download request
-            var response = await _client.SendAsync(request, cancelToken);
+			// Send the download request
+			var response = await _client.SendAsync(request, cancelToken);
 
-            // Create B2File from response
-            return await ParseDownloadResponse(response);
-        }
+			// Create B2File from response
+			return await ParseDownloadResponse(response);
+		}
 
-        /// <summary>
-        /// Downloads one file by providing the name of the bucket and the name of the file.
-        /// </summary>
-        /// <param name="fileId"></param>
-        /// <param name="fileName"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2File> DownloadByName(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken)) {
+		/// <summary>
+		/// Downloads one file by providing the name of the bucket and the name of the file.
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="fileName"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> DownloadByName(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken)) {
 			// Are we searching by name or id?
 			HttpRequestMessage request;
 			request = FileDownloadRequestGenerators.DownloadByName(_options, bucketName, fileName);
@@ -235,52 +233,52 @@ namespace B2Net
 
 			// Create B2File from response
 			return await ParseDownloadResponse(response);
-	    }
+		}
 
-	    /// <summary>
-	    /// Downloads a file from B2 using the byte range specified. For use with the Large File API.
-	    /// </summary>
-	    /// <param name="fileId"></param>
-	    /// <param name="cancelToken"></param>
-	    /// <returns></returns>
-	    public async Task<B2File> DownloadById(string fileId, int startByte, int endByte, CancellationToken cancelToken = default(CancellationToken)) {
-	        // Are we searching by name or id?
-	        HttpRequestMessage request;
-	        request = FileDownloadRequestGenerators.DownloadById(_options, fileId, $"{startByte}-{endByte}");
+		/// <summary>
+		/// Downloads a file from B2 using the byte range specified. For use with the Large File API.
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> DownloadById(string fileId, int startByte, int endByte, CancellationToken cancelToken = default(CancellationToken)) {
+			// Are we searching by name or id?
+			HttpRequestMessage request;
+			request = FileDownloadRequestGenerators.DownloadById(_options, fileId, $"{startByte}-{endByte}");
 
-	        // Send the download request
-	        var response = await _client.SendAsync(request, cancelToken);
+			// Send the download request
+			var response = await _client.SendAsync(request, cancelToken);
 
-	        // Create B2File from response
-	        return await ParseDownloadResponse(response);
-	    }
+			// Create B2File from response
+			return await ParseDownloadResponse(response);
+		}
 
-	    /// <summary>
-	    /// Downloads one file from B2.
-	    /// </summary>
-	    /// <param name="fileId"></param>
-	    /// <param name="cancelToken"></param>
-	    /// <returns></returns>
-	    public async Task<B2File> DownloadById(string fileId, CancellationToken cancelToken = default(CancellationToken)) {
-	        // Are we searching by name or id?
-	        HttpRequestMessage request;
-	        request = FileDownloadRequestGenerators.DownloadById(_options, fileId);
+		/// <summary>
+		/// Downloads one file from B2.
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> DownloadById(string fileId, CancellationToken cancelToken = default(CancellationToken)) {
+			// Are we searching by name or id?
+			HttpRequestMessage request;
+			request = FileDownloadRequestGenerators.DownloadById(_options, fileId);
 
-	        // Send the download request
-	        var response = await _client.SendAsync(request, cancelToken);
+			// Send the download request
+			var response = await _client.SendAsync(request, cancelToken);
 
-	        // Create B2File from response
-	        return await ParseDownloadResponse(response);
-	    }
+			// Create B2File from response
+			return await ParseDownloadResponse(response);
+		}
 
-        /// <summary>
-        /// Deletes the specified file version
-        /// </summary>
-        /// <param name="fileId"></param>
-        /// <param name="fileName"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2File> Delete(string fileId, string fileName, CancellationToken cancelToken = default(CancellationToken)) {
+		/// <summary>
+		/// Deletes the specified file version
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="fileName"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> Delete(string fileId, string fileName, CancellationToken cancelToken = default(CancellationToken)) {
 			var requestMessage = FileDeleteRequestGenerator.Delete(_options, fileId, fileName);
 			var response = await _client.SendAsync(requestMessage, cancelToken);
 
@@ -288,23 +286,23 @@ namespace B2Net
 		}
 
 
-        /// <summary>
-        /// EXPERIMENTAL: This functionality is not officially part of the Backblaze B2 API and may change or break at any time.
-        /// This will return a friendly URL that can be shared to download the file. This depends on the Bucket that the file resides 
-        /// in to be allPublic.
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="bucketName"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-	    public string GetFriendlyDownloadUrl(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken)) {
-	        var downloadUrl = _options.DownloadUrl;
-	        var friendlyUrl = "";
-            if (!string.IsNullOrEmpty(downloadUrl)) {
-                friendlyUrl = $"{downloadUrl}/file/{bucketName}/{fileName}";
-            }
-	        return friendlyUrl;
-	    }
+		/// <summary>
+		/// EXPERIMENTAL: This functionality is not officially part of the Backblaze B2 API and may change or break at any time.
+		/// This will return a friendly URL that can be shared to download the file. This depends on the Bucket that the file resides
+		/// in to be allPublic.
+		/// </summary>
+		/// <param name="fileName"></param>
+		/// <param name="bucketName"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public string GetFriendlyDownloadUrl(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken)) {
+			var downloadUrl = _options.DownloadUrl;
+			var friendlyUrl = "";
+			if (!string.IsNullOrEmpty(downloadUrl)) {
+				friendlyUrl = $"{downloadUrl}/file/{bucketName}/{fileName}";
+			}
+			return friendlyUrl;
+		}
 
 		/// <summary>
 		/// Hides or Unhides a file so that downloading by name will not find the file,
@@ -358,21 +356,20 @@ namespace B2Net
 			if (response.Headers.TryGetValues("X-Bz-File-Id", out values)) {
 				file.FileId = values.First();
 			}
-            // File Info Headers
-            var fileInfoHeaders = response.Headers.Where(h => h.Key.ToLower().Contains("x-bz-info"));
-            var infoData = new Dictionary<string, string>();
-            if (fileInfoHeaders.Count() > 0) {
-                foreach (var fileInfo in fileInfoHeaders)
-                {
-                    // Substring to parse out the file info prefix.
-                    infoData.Add(fileInfo.Key.Substring(10), fileInfo.Value.First());
-                }
-            }
-            file.FileInfo = infoData;
-            if (response.Content.Headers.ContentLength.HasValue) {
-                file.Size = response.Content.Headers.ContentLength.Value;
-            }
-            file.FileData = await response.Content.ReadAsByteArrayAsync();
+			// File Info Headers
+			var fileInfoHeaders = response.Headers.Where(h => h.Key.ToLower().Contains("x-bz-info"));
+			var infoData = new Dictionary<string, string>();
+			if (fileInfoHeaders.Count() > 0) {
+				foreach (var fileInfo in fileInfoHeaders) {
+					// Substring to parse out the file info prefix.
+					infoData.Add(fileInfo.Key.Substring(10), fileInfo.Value.First());
+				}
+			}
+			file.FileInfo = infoData;
+			if (response.Content.Headers.ContentLength.HasValue) {
+				file.Size = response.Content.Headers.ContentLength.Value;
+			}
+			file.FileData = await response.Content.ReadAsByteArrayAsync();
 
 			return await Task.FromResult(file);
 		}

--- a/src/Http/HttpClientFactory.cs
+++ b/src/Http/HttpClientFactory.cs
@@ -4,20 +4,20 @@ using System.Net.Http.Headers;
 
 namespace B2Net.Http {
 	public static class HttpClientFactory {
-	    private static HttpClient _client;
+		private static HttpClient _client;
 
-        public static HttpClient CreateHttpClient(int timeout) {
-            if (_client == null) {
-                var handler = new HttpClientHandler() { AllowAutoRedirect = true };
+		public static HttpClient CreateHttpClient(int timeout) {
+			if (_client == null) {
+				var handler = new HttpClientHandler() { AllowAutoRedirect = true };
 
-                _client = new HttpClient(handler);
+				_client = new HttpClient(handler);
 
-                _client.Timeout = TimeSpan.FromSeconds(timeout);
+				_client.Timeout = TimeSpan.FromSeconds(timeout);
 
-                _client.DefaultRequestHeaders.Accept.Clear();
-                _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            }
-            return _client;
-        }
+				_client.DefaultRequestHeaders.Accept.Clear();
+				_client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+			}
+			return _client;
+		}
 	}
 }

--- a/src/Http/RequestGenerators/AuthRequestGenerator.cs
+++ b/src/Http/RequestGenerators/AuthRequestGenerator.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using B2Net.Models;
+using System;
 using System.Net.Http;
-using B2Net.Models;
 
 namespace B2Net.Http {
 	public static class AuthRequestGenerator {

--- a/src/Http/RequestGenerators/BaseRequestGenerator.cs
+++ b/src/Http/RequestGenerators/BaseRequestGenerator.cs
@@ -1,37 +1,37 @@
-﻿using System;
+﻿using B2Net.Models;
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using B2Net.Models;
 
 namespace B2Net.Http.RequestGenerators {
 	public static class BaseRequestGenerator {
-	    public static HttpRequestMessage PostRequest(string endpoint, string body, B2Options options) {
-	        var uri = new Uri(options.ApiUrl + "/b2api/" + Constants.Version + "/" + endpoint);
-	        var request = new HttpRequestMessage() {
-	            Method = HttpMethod.Post,
-	            RequestUri = uri,
-	            Content = new StringContent(body)
-	        };
-            
-            request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
+		public static HttpRequestMessage PostRequest(string endpoint, string body, B2Options options) {
+			var uri = new Uri(options.ApiUrl + "/b2api/" + Constants.Version + "/" + endpoint);
+			var request = new HttpRequestMessage() {
+				Method = HttpMethod.Post,
+				RequestUri = uri,
+				Content = new StringContent(body)
+			};
 
-	        return request;
-	    }
+			request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
 
-	    public static HttpRequestMessage PostRequestJson(string endpoint, string body, B2Options options) {
-	        var uri = new Uri(options.ApiUrl + "/b2api/" + Constants.Version + "/" + endpoint);
-	        var request = new HttpRequestMessage() {
-	            Method = HttpMethod.Post,
-	            RequestUri = uri,
-	            Content = new StringContent(body)
-	        };
+			return request;
+		}
 
-	        request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
+		public static HttpRequestMessage PostRequestJson(string endpoint, string body, B2Options options) {
+			var uri = new Uri(options.ApiUrl + "/b2api/" + Constants.Version + "/" + endpoint);
+			var request = new HttpRequestMessage() {
+				Method = HttpMethod.Post,
+				RequestUri = uri,
+				Content = new StringContent(body)
+			};
 
-	        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-	        request.Content.Headers.ContentLength = body.Length;
+			request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
 
-            return request;
-	    }
-    }
+			request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+			request.Content.Headers.ContentLength = body.Length;
+
+			return request;
+		}
+	}
 }

--- a/src/Http/RequestGenerators/BucketRequestGenerators.cs
+++ b/src/Http/RequestGenerators/BucketRequestGenerators.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Net.Http;
-using B2Net.Http.RequestGenerators;
+﻿using B2Net.Http.RequestGenerators;
 using B2Net.Models;
 using Newtonsoft.Json;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.RegularExpressions;
 
 namespace B2Net.Http {
 	public static class BucketRequestGenerators {
@@ -17,156 +17,151 @@ namespace B2Net.Http {
 		}
 
 		public static HttpRequestMessage GetBucketList(B2Options options) {
-		    var json = JsonConvert.SerializeObject(new { accountId = options.AccountId });
-            return BaseRequestGenerator.PostRequest(Endpoints.List, json, options);
+			var json = JsonConvert.SerializeObject(new { accountId = options.AccountId });
+			return BaseRequestGenerator.PostRequest(Endpoints.List, json, options);
 		}
 
 		public static HttpRequestMessage DeleteBucket(B2Options options, string bucketId) {
-		    var json = JsonConvert.SerializeObject(new { accountId = options.AccountId, bucketId });
-            return BaseRequestGenerator.PostRequest(Endpoints.Delete, json, options);
-        }
+			var json = JsonConvert.SerializeObject(new { accountId = options.AccountId, bucketId });
+			return BaseRequestGenerator.PostRequest(Endpoints.Delete, json, options);
+		}
 
-        /// <summary>
-        /// Create a bucket. Defaults to allPrivate.
-        /// </summary>
-        /// <param name="options"></param>
-        /// <param name="bucketName"></param>
-        /// <param name="bucketType"></param>
-        /// <returns></returns>
-        public static HttpRequestMessage CreateBucket(B2Options options, string bucketName, string bucketType = "allPrivate") {
-            var allowed = new Regex("^[a-zA-Z0-9-]+$");
-            if (bucketName.Length < 6 || bucketName.Length > 50 || !allowed.IsMatch(bucketName) || bucketName.StartsWith("b2-")) {
-                throw new Exception(@"The bucket name specified does not match the requirements. 
+		/// <summary>
+		/// Create a bucket. Defaults to allPrivate.
+		/// </summary>
+		/// <param name="options"></param>
+		/// <param name="bucketName"></param>
+		/// <param name="bucketType"></param>
+		/// <returns></returns>
+		public static HttpRequestMessage CreateBucket(B2Options options, string bucketName, string bucketType = "allPrivate") {
+			var allowed = new Regex("^[a-zA-Z0-9-]+$");
+			if (bucketName.Length < 6 || bucketName.Length > 50 || !allowed.IsMatch(bucketName) || bucketName.StartsWith("b2-")) {
+				throw new Exception(@"The bucket name specified does not match the requirements. 
                             Bucket Name can consist of upper-case letters, lower-case letters, numbers, and "" - "", 
                             must be at least 6 characters long, and can be at most 50 characters long");
-            }
+			}
 
-            var json = JsonConvert.SerializeObject(new { accountId = options.AccountId, bucketName, bucketType });
-            return BaseRequestGenerator.PostRequest(Endpoints.Create, json, options);
-        }
+			var json = JsonConvert.SerializeObject(new { accountId = options.AccountId, bucketName, bucketType });
+			return BaseRequestGenerator.PostRequest(Endpoints.Create, json, options);
+		}
 
-        /// <summary>
-        /// Create a bucket. Defaults to allPrivate.
-        /// </summary>
-        /// <param name="options"></param>
-        /// <param name="bucketName"></param>
-        /// <param name="bucketType"></param>
-        /// <returns></returns>
-        public static HttpRequestMessage CreateBucket(B2Options options, string bucketName, B2BucketOptions bucketOptions)
-        {
-            // Check lifecycle rules
-            var hasLifecycleRules = bucketOptions.LifecycleRules != null && bucketOptions.LifecycleRules.Count > 0;
-            if (hasLifecycleRules) {
-                foreach (var rule in bucketOptions.LifecycleRules) {
-                    if (rule.DaysFromHidingToDeleting < 1 || rule.DaysFromUploadingToHiding < 1) {
-                        throw new System.Exception("The smallest number of days you can set in a lifecycle rule is 1.");
-                    }
-                    if (rule.DaysFromHidingToDeleting == null && rule.DaysFromUploadingToHiding == null) {
-                        throw new System.Exception("You must set either DaysFromHidingToDeleting or DaysFromUploadingToHiding. Both cannot be null.");
-                    }
-                }
-            }
+		/// <summary>
+		/// Create a bucket. Defaults to allPrivate.
+		/// </summary>
+		/// <param name="options"></param>
+		/// <param name="bucketName"></param>
+		/// <param name="bucketType"></param>
+		/// <returns></returns>
+		public static HttpRequestMessage CreateBucket(B2Options options, string bucketName, B2BucketOptions bucketOptions) {
+			// Check lifecycle rules
+			var hasLifecycleRules = bucketOptions.LifecycleRules != null && bucketOptions.LifecycleRules.Count > 0;
+			if (hasLifecycleRules) {
+				foreach (var rule in bucketOptions.LifecycleRules) {
+					if (rule.DaysFromHidingToDeleting < 1 || rule.DaysFromUploadingToHiding < 1) {
+						throw new System.Exception("The smallest number of days you can set in a lifecycle rule is 1.");
+					}
+					if (rule.DaysFromHidingToDeleting == null && rule.DaysFromUploadingToHiding == null) {
+						throw new System.Exception("You must set either DaysFromHidingToDeleting or DaysFromUploadingToHiding. Both cannot be null.");
+					}
+				}
+			}
 
-            var allowed = new Regex("^[a-zA-Z0-9-]+$");
-            if (bucketName.Length < 6 || bucketName.Length > 50 || !allowed.IsMatch(bucketName) || bucketName.StartsWith("b2-")) {
-                throw new Exception(@"The bucket name specified does not match the requirements. 
+			var allowed = new Regex("^[a-zA-Z0-9-]+$");
+			if (bucketName.Length < 6 || bucketName.Length > 50 || !allowed.IsMatch(bucketName) || bucketName.StartsWith("b2-")) {
+				throw new Exception(@"The bucket name specified does not match the requirements. 
                             Bucket Name can consist of upper-case letters, lower-case letters, numbers, and "" - "", 
                             must be at least 6 characters long, and can be at most 50 characters long");
-            }
+			}
 
-            var body = new B2BucketCreateModel() {
-                accountId = options.AccountId,
-                bucketName = bucketName,
-                bucketType = bucketOptions.BucketType.ToString()
-            };
+			var body = new B2BucketCreateModel() {
+				accountId = options.AccountId,
+				bucketName = bucketName,
+				bucketType = bucketOptions.BucketType.ToString()
+			};
 
-            // Add optional options
-            if (bucketOptions.CacheControl != 0) {
-                body.bucketInfo = new Dictionary<string, string>() {
-                    { "Cache-Control", "max-age=" + bucketOptions.CacheControl }
-                };
-            }
-            if(hasLifecycleRules) {
-                body.lifecycleRules = bucketOptions.LifecycleRules;
-            }
+			// Add optional options
+			if (bucketOptions.CacheControl != 0) {
+				body.bucketInfo = new Dictionary<string, string>() {
+					{ "Cache-Control", "max-age=" + bucketOptions.CacheControl }
+				};
+			}
+			if (hasLifecycleRules) {
+				body.lifecycleRules = bucketOptions.LifecycleRules;
+			}
 
-            var json = JsonSerialize(body);
-            return BaseRequestGenerator.PostRequest(Endpoints.Create, json, options);
-        }
+			var json = JsonSerialize(body);
+			return BaseRequestGenerator.PostRequest(Endpoints.Create, json, options);
+		}
 
-        /// <summary>
-        /// Used to modify the bucket type of the provided bucket.
-        /// </summary>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public static HttpRequestMessage UpdateBucket(B2Options options, string bucketId, string bucketType) {
-            var json = JsonConvert.SerializeObject(new { accountId = options.AccountId, bucketId, bucketType });
-            return BaseRequestGenerator.PostRequest(Endpoints.Update, json, options);
-        }
+		/// <summary>
+		/// Used to modify the bucket type of the provided bucket.
+		/// </summary>
+		/// <param name="options"></param>
+		/// <returns></returns>
+		public static HttpRequestMessage UpdateBucket(B2Options options, string bucketId, string bucketType) {
+			var json = JsonConvert.SerializeObject(new { accountId = options.AccountId, bucketId, bucketType });
+			return BaseRequestGenerator.PostRequest(Endpoints.Update, json, options);
+		}
 
-        /// <summary>
-        /// Used to modify the bucket type of the provided bucket.
-        /// </summary>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public static HttpRequestMessage UpdateBucket(B2Options options, string bucketId, B2BucketOptions bucketOptions)
-        {
-            // Check lifecycle rules
-            var hasLifecycleRules = bucketOptions.LifecycleRules != null && bucketOptions.LifecycleRules.Count > 0;
-            if (hasLifecycleRules) {
-                foreach (var rule in bucketOptions.LifecycleRules) {
-                    if (rule.DaysFromHidingToDeleting < 1 || rule.DaysFromUploadingToHiding < 1) {
-                        throw new System.Exception("The smallest number of days you can set in a lifecycle rule is 1.");
-                    }
-                    if (rule.DaysFromHidingToDeleting == null && rule.DaysFromUploadingToHiding == null) {
-                        throw new System.Exception("You must set either DaysFromHidingToDeleting or DaysFromUploadingToHiding. Both cannot be null.");
-                    }
-                }
-            }
+		/// <summary>
+		/// Used to modify the bucket type of the provided bucket.
+		/// </summary>
+		/// <param name="options"></param>
+		/// <returns></returns>
+		public static HttpRequestMessage UpdateBucket(B2Options options, string bucketId, B2BucketOptions bucketOptions) {
+			// Check lifecycle rules
+			var hasLifecycleRules = bucketOptions.LifecycleRules != null && bucketOptions.LifecycleRules.Count > 0;
+			if (hasLifecycleRules) {
+				foreach (var rule in bucketOptions.LifecycleRules) {
+					if (rule.DaysFromHidingToDeleting < 1 || rule.DaysFromUploadingToHiding < 1) {
+						throw new System.Exception("The smallest number of days you can set in a lifecycle rule is 1.");
+					}
+					if (rule.DaysFromHidingToDeleting == null && rule.DaysFromUploadingToHiding == null) {
+						throw new System.Exception("You must set either DaysFromHidingToDeleting or DaysFromUploadingToHiding. Both cannot be null.");
+					}
+				}
+			}
 
-            var body = new B2BucketUpdateModel()
-            {
-                accountId = options.AccountId,
-                bucketId = bucketId,
-                bucketType = bucketOptions.BucketType.ToString()
-            };
+			var body = new B2BucketUpdateModel() {
+				accountId = options.AccountId,
+				bucketId = bucketId,
+				bucketType = bucketOptions.BucketType.ToString()
+			};
 
-            // Add optional options
-            if (bucketOptions.CacheControl != 0) {
-                body.bucketInfo = new Dictionary<string, string>() {
-                    { "Cache-Control", "max-age=" + bucketOptions.CacheControl }
-                };
-            }
-            if (hasLifecycleRules) {
-                body.lifecycleRules = bucketOptions.LifecycleRules;
-            }
+			// Add optional options
+			if (bucketOptions.CacheControl != 0) {
+				body.bucketInfo = new Dictionary<string, string>() {
+					{ "Cache-Control", "max-age=" + bucketOptions.CacheControl }
+				};
+			}
+			if (hasLifecycleRules) {
+				body.lifecycleRules = bucketOptions.LifecycleRules;
+			}
 
-            var json = JsonSerialize(body);
-            return BaseRequestGenerator.PostRequest(Endpoints.Update, json, options);
-        }
+			var json = JsonSerialize(body);
+			return BaseRequestGenerator.PostRequest(Endpoints.Update, json, options);
+		}
 
-        private static string JsonSerialize(object data){
-            return JsonConvert.SerializeObject(data, Formatting.Indented, new JsonSerializerSettings() {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            });
-        }
-    }
+		private static string JsonSerialize(object data) {
+			return JsonConvert.SerializeObject(data, Formatting.Indented, new JsonSerializerSettings() {
+				ContractResolver = new CamelCasePropertyNamesContractResolver()
+			});
+		}
+	}
 
-    internal class B2BucketCreateModel
-    {
-        public string accountId { get; set; }
-        public string bucketName { get; set; }
-        public string bucketType { get; set; }
-        public Dictionary<string, string> bucketInfo { get; set; }
-        public List<B2BucketLifecycleRule> lifecycleRules { get; set; }
-    }
+	internal class B2BucketCreateModel {
+		public string accountId { get; set; }
+		public string bucketName { get; set; }
+		public string bucketType { get; set; }
+		public Dictionary<string, string> bucketInfo { get; set; }
+		public List<B2BucketLifecycleRule> lifecycleRules { get; set; }
+	}
 
-    internal class B2BucketUpdateModel
-    {
-        public string accountId { get; set; }
-        public string bucketId { get; set; }
-        public string bucketType { get; set; }
-        public Dictionary<string, string> bucketInfo { get; set; }
-        public List<B2BucketLifecycleRule> lifecycleRules { get; set; }
-    }
+	internal class B2BucketUpdateModel {
+		public string accountId { get; set; }
+		public string bucketId { get; set; }
+		public string bucketType { get; set; }
+		public Dictionary<string, string> bucketInfo { get; set; }
+		public List<B2BucketLifecycleRule> lifecycleRules { get; set; }
+	}
 }

--- a/src/Http/RequestGenerators/FileDeleteRequestGenerator.cs
+++ b/src/Http/RequestGenerators/FileDeleteRequestGenerator.cs
@@ -1,7 +1,7 @@
-﻿using System.Net.Http;
-using B2Net.Http.RequestGenerators;
+﻿using B2Net.Http.RequestGenerators;
 using B2Net.Models;
 using Newtonsoft.Json;
+using System.Net.Http;
 
 namespace B2Net.Http {
 	public static class FileDeleteRequestGenerator {
@@ -10,8 +10,8 @@ namespace B2Net.Http {
 		}
 
 		public static HttpRequestMessage Delete(B2Options options, string fileId, string fileName) {
-		    var json = JsonConvert.SerializeObject(new { fileId, fileName });
-            return BaseRequestGenerator.PostRequest(Endpoints.Delete, json, options);
+			var json = JsonConvert.SerializeObject(new { fileId, fileName });
+			return BaseRequestGenerator.PostRequest(Endpoints.Delete, json, options);
 		}
 	}
 }

--- a/src/Http/RequestGenerators/FileDownloadRequestGenerators.cs
+++ b/src/Http/RequestGenerators/FileDownloadRequestGenerators.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Net.Http;
-using B2Net.Models;
+﻿using B2Net.Models;
 using Newtonsoft.Json;
+using System;
+using System.Net.Http;
 
 namespace B2Net.Http {
 	public static class FileDownloadRequestGenerators {
@@ -14,8 +14,8 @@ namespace B2Net.Http {
 		public static HttpRequestMessage DownloadById(B2Options options, string fileId, string byteRange = "") {
 			var uri = new Uri(options.DownloadUrl + "/b2api/" + Constants.Version + "/" + Endpoints.DownloadById);
 
-		    var json = JsonConvert.SerializeObject(new { fileId });
-            var request = new HttpRequestMessage() {
+			var json = JsonConvert.SerializeObject(new { fileId });
+			var request = new HttpRequestMessage() {
 				Method = HttpMethod.Post,
 				RequestUri = uri,
 				Content = new StringContent(json)
@@ -23,12 +23,12 @@ namespace B2Net.Http {
 
 			request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
 
-		    // Add byte range header if we have it
-		    if (!string.IsNullOrEmpty(byteRange)) {
-		        request.Headers.Add("Range", $"bytes={byteRange}");
-		    }
+			// Add byte range header if we have it
+			if (!string.IsNullOrEmpty(byteRange)) {
+				request.Headers.Add("Range", $"bytes={byteRange}");
+			}
 
-            return request;
+			return request;
 		}
 
 		public static HttpRequestMessage DownloadByName(B2Options options, string bucketName, string fileName, string byteRange = "") {
@@ -38,12 +38,12 @@ namespace B2Net.Http {
 				RequestUri = uri
 			};
 
-		    request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
+			request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
 
-            // Add byte range header if we have it
-            if (!string.IsNullOrEmpty(byteRange)) {
-		        request.Headers.Add("Range", $"bytes={byteRange}");
-		    }
+			// Add byte range header if we have it
+			if (!string.IsNullOrEmpty(byteRange)) {
+				request.Headers.Add("Range", $"bytes={byteRange}");
+			}
 
 			return request;
 		}
@@ -52,20 +52,20 @@ namespace B2Net.Http {
 			var uri = new Uri(options.ApiUrl + "/b2api/" + Constants.Version + "/" + Endpoints.GetDownloadAuthorization);
 
 			var body = "{\"bucketId\":" + JsonConvert.ToString(bucketId) + ", \"fileNamePrefix\":" +
-			           JsonConvert.ToString(fileNamePrefix) + ", \"validDurationInSeconds\":" +
-			           JsonConvert.ToString(validDurationInSeconds);
+					   JsonConvert.ToString(fileNamePrefix) + ", \"validDurationInSeconds\":" +
+					   JsonConvert.ToString(validDurationInSeconds);
 			if (!string.IsNullOrEmpty(b2ContentDisposition)) {
 				body += ", \"maxFileCount\":" + JsonConvert.ToString(b2ContentDisposition);
 			}
 			body += "}";
-			
+
 			var request = new HttpRequestMessage() {
 				Method = HttpMethod.Post,
 				RequestUri = uri,
 				Content = new StringContent(body)
 			};
 
-			request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken); 
+			request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
 
 			return request;
 		}

--- a/src/Http/RequestGenerators/FileMetaDataRequestGenerators.cs
+++ b/src/Http/RequestGenerators/FileMetaDataRequestGenerators.cs
@@ -1,7 +1,7 @@
-﻿using System.Net.Http;
-using B2Net.Http.RequestGenerators;
+﻿using B2Net.Http.RequestGenerators;
 using B2Net.Models;
 using Newtonsoft.Json;
+using System.Net.Http;
 
 namespace B2Net.Http {
 	public static class FileMetaDataRequestGenerators {
@@ -16,18 +16,18 @@ namespace B2Net.Http {
 			var body = "{\"bucketId\":\"" + bucketId + "\"";
 			if (!string.IsNullOrEmpty(startFileName)) {
 				body += ", \"startFileName\":" + JsonConvert.ToString(startFileName);
-		    }
-		    if (maxFileCount.HasValue) {
-		        body += ", \"maxFileCount\":" + maxFileCount.Value.ToString();
-            }
-		    if (!string.IsNullOrEmpty(prefix)) {
-		        body += ", \"prefix\":" + JsonConvert.ToString(prefix);
-		    }
-		    if (!string.IsNullOrEmpty(delimiter)) {
-		        body += ", \"delimiter\":" + JsonConvert.ToString(delimiter);
-		    }
-            body += "}";
-            return BaseRequestGenerator.PostRequest(Endpoints.List, body, options);
+			}
+			if (maxFileCount.HasValue) {
+				body += ", \"maxFileCount\":" + maxFileCount.Value.ToString();
+			}
+			if (!string.IsNullOrEmpty(prefix)) {
+				body += ", \"prefix\":" + JsonConvert.ToString(prefix);
+			}
+			if (!string.IsNullOrEmpty(delimiter)) {
+				body += ", \"delimiter\":" + JsonConvert.ToString(delimiter);
+			}
+			body += "}";
+			return BaseRequestGenerator.PostRequest(Endpoints.List, body, options);
 		}
 
 		public static HttpRequestMessage ListVersions(B2Options options, string bucketId, string startFileName = "", string startFileId = "", int? maxFileCount = null, string prefix = "", string delimiter = "") {
@@ -38,35 +38,33 @@ namespace B2Net.Http {
 			if (!string.IsNullOrEmpty(startFileId)) {
 				body += ", \"startFileId\":\"" + startFileId + "\"";
 			}
-            if (maxFileCount.HasValue) {
-                body += ", \"maxFileCount\":" + maxFileCount.Value.ToString();
-            }
-		    if (!string.IsNullOrEmpty(prefix)) {
-		        body += ", \"prefix\":" + JsonConvert.ToString(prefix);
-		    }
-		    if (!string.IsNullOrEmpty(delimiter)) {
-		        body += ", \"delimiter\":" + JsonConvert.ToString(delimiter);
-            }
-            body += "}";
+			if (maxFileCount.HasValue) {
+				body += ", \"maxFileCount\":" + maxFileCount.Value.ToString();
+			}
+			if (!string.IsNullOrEmpty(prefix)) {
+				body += ", \"prefix\":" + JsonConvert.ToString(prefix);
+			}
+			if (!string.IsNullOrEmpty(delimiter)) {
+				body += ", \"delimiter\":" + JsonConvert.ToString(delimiter);
+			}
+			body += "}";
 			return BaseRequestGenerator.PostRequest(Endpoints.Versions, body, options);
 		}
 
 		public static HttpRequestMessage HideFile(B2Options options, string bucketId, string fileName = "", string fileId = "") {
-            var body = "{\"bucketId\":\"" + bucketId + "\"";
-            if (!string.IsNullOrEmpty(fileName) && string.IsNullOrEmpty(fileId))
-            {
-                body += ", \"fileName\":" + JsonConvert.ToString(fileName);
-            }
-            if (!string.IsNullOrEmpty(fileId))
-            {
-                body += ", \"fileId\":\"" + fileId + "\"";
-            }
-            body += "}";
-            return BaseRequestGenerator.PostRequest(Endpoints.Hide, body, options);
+			var body = "{\"bucketId\":\"" + bucketId + "\"";
+			if (!string.IsNullOrEmpty(fileName) && string.IsNullOrEmpty(fileId)) {
+				body += ", \"fileName\":" + JsonConvert.ToString(fileName);
+			}
+			if (!string.IsNullOrEmpty(fileId)) {
+				body += ", \"fileId\":\"" + fileId + "\"";
+			}
+			body += "}";
+			return BaseRequestGenerator.PostRequest(Endpoints.Hide, body, options);
 		}
 
 		public static HttpRequestMessage GetInfo(B2Options options, string fileId) {
-		    var json = JsonConvert.SerializeObject(new {fileId});
+			var json = JsonConvert.SerializeObject(new { fileId });
 			return BaseRequestGenerator.PostRequest(Endpoints.Info, json, options);
 		}
 	}

--- a/src/Http/RequestGenerators/FileUploadRequestGenerators.cs
+++ b/src/Http/RequestGenerators/FileUploadRequestGenerators.cs
@@ -13,52 +13,48 @@ namespace B2Net.Http {
 			public const string GetUploadUrl = "b2_get_upload_url";
 		}
 
-        /// <summary>
-        /// Upload a file to B2. This method will calculate the SHA1 checksum before sending any data.
-        /// </summary>
-        /// <param name="options"></param>
-        /// <param name="uploadUrl"></param>
-        /// <param name="fileData"></param>
-        /// <param name="fileName"></param>
-        /// <param name="fileInfo"></param>
-        /// <returns></returns>
-        public static HttpRequestMessage Upload(B2Options options, string uploadUrl, byte[] fileData, string fileName, Dictionary<string, string> fileInfo)
-        {
-            var uri = new Uri(uploadUrl);
-            var request = new HttpRequestMessage()
-            {
-                Method = HttpMethod.Post,
-                RequestUri = uri,
-                Content = new ByteArrayContent(fileData)
-            };
+		/// <summary>
+		/// Upload a file to B2. This method will calculate the SHA1 checksum before sending any data.
+		/// </summary>
+		/// <param name="options"></param>
+		/// <param name="uploadUrl"></param>
+		/// <param name="fileData"></param>
+		/// <param name="fileName"></param>
+		/// <param name="fileInfo"></param>
+		/// <returns></returns>
+		public static HttpRequestMessage Upload(B2Options options, string uploadUrl, byte[] fileData, string fileName, Dictionary<string, string> fileInfo) {
+			var uri = new Uri(uploadUrl);
+			var request = new HttpRequestMessage() {
+				Method = HttpMethod.Post,
+				RequestUri = uri,
+				Content = new ByteArrayContent(fileData)
+			};
 
-            // Get the file checksum
-            string hash = Utilities.GetSHA1Hash(fileData);
+			// Get the file checksum
+			string hash = Utilities.GetSHA1Hash(fileData);
 
-            // Add headers
-            request.Headers.TryAddWithoutValidation("Authorization", options.UploadAuthorizationToken);
-            request.Headers.Add("X-Bz-File-Name", fileName.b2UrlEncode());
-            request.Headers.Add("X-Bz-Content-Sha1", hash);
-            // File Info headers
-            if (fileInfo != null && fileInfo.Count > 0)
-            {
-                foreach (var info in fileInfo.Take(10))
-                {
-                    request.Headers.Add($"X-Bz-Info-{info.Key}", info.Value);
-                }
-            }
-            // TODO last modified
-            //request.Headers.Add("X-Bz-src_last_modified_millis", hash);
+			// Add headers
+			request.Headers.TryAddWithoutValidation("Authorization", options.UploadAuthorizationToken);
+			request.Headers.Add("X-Bz-File-Name", fileName.b2UrlEncode());
+			request.Headers.Add("X-Bz-Content-Sha1", hash);
+			// File Info headers
+			if (fileInfo != null && fileInfo.Count > 0) {
+				foreach (var info in fileInfo.Take(10)) {
+					request.Headers.Add($"X-Bz-Info-{info.Key}", info.Value);
+				}
+			}
+			// TODO last modified
+			//request.Headers.Add("X-Bz-src_last_modified_millis", hash);
 
-            request.Content.Headers.ContentType = new MediaTypeHeaderValue("b2/x-auto");
-            request.Content.Headers.ContentLength = fileData.Length;
+			request.Content.Headers.ContentType = new MediaTypeHeaderValue("b2/x-auto");
+			request.Content.Headers.ContentLength = fileData.Length;
 
-            return request;
-        }
+			return request;
+		}
 
-        public static HttpRequestMessage GetUploadUrl(B2Options options, string bucketId) {
-            var json = JsonConvert.SerializeObject(new { bucketId });
-            return BaseRequestGenerator.PostRequest(Endpoints.GetUploadUrl, json, options);
+		public static HttpRequestMessage GetUploadUrl(B2Options options, string bucketId) {
+			var json = JsonConvert.SerializeObject(new { bucketId });
+			return BaseRequestGenerator.PostRequest(Endpoints.GetUploadUrl, json, options);
 		}
 	}
 }

--- a/src/Http/RequestGenerators/LargeFileRequestGenerators.cs
+++ b/src/Http/RequestGenerators/LargeFileRequestGenerators.cs
@@ -1,121 +1,116 @@
-﻿using System;
-using System.Collections;
+﻿using B2Net.Models;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.Serialization;
-using System.Text;
-using B2Net.Models;
-using Newtonsoft.Json;
 
-namespace B2Net.Http.RequestGenerators
-{
-    public class LargeFileRequestGenerators
-    {
-        private static class Endpoints {
-            public const string Start = "b2_start_large_file";
-            public const string GetPartUrl = "b2_get_upload_part_url";
-            public const string Upload = "b2_upload_part";
-            public const string Finish = "b2_finish_large_file";
-            public const string ListParts = "b2_list_parts";
-            public const string Cancel = "b2_cancel_large_file";
-            public const string IncompleteFiles = "b2_list_unfinished_large_files";
-        }
+namespace B2Net.Http.RequestGenerators {
+	public class LargeFileRequestGenerators {
+		private static class Endpoints {
+			public const string Start = "b2_start_large_file";
+			public const string GetPartUrl = "b2_get_upload_part_url";
+			public const string Upload = "b2_upload_part";
+			public const string Finish = "b2_finish_large_file";
+			public const string ListParts = "b2_list_parts";
+			public const string Cancel = "b2_cancel_large_file";
+			public const string IncompleteFiles = "b2_list_unfinished_large_files";
+		}
 
-        public static HttpRequestMessage Start(B2Options options, string bucketId, string fileName, string contentType, Dictionary<string, string> fileInfo = null) {
-            var uri = new Uri(options.ApiUrl + "/b2api/" + Constants.Version + "/" + Endpoints.Start);
-            var content = "{\"bucketId\":\"" + bucketId + "\",\"fileName\":\"" + fileName +
-                                            "\",\"contentType\":\"" + (string.IsNullOrEmpty(contentType) ? "b2/x-auto" : contentType) + "\"}";
-            var request = new HttpRequestMessage() {
-                Method = HttpMethod.Post,
-                RequestUri = uri,
-                Content = new StringContent(content),
-            };
+		public static HttpRequestMessage Start(B2Options options, string bucketId, string fileName, string contentType, Dictionary<string, string> fileInfo = null) {
+			var uri = new Uri(options.ApiUrl + "/b2api/" + Constants.Version + "/" + Endpoints.Start);
+			var content = "{\"bucketId\":\"" + bucketId + "\",\"fileName\":\"" + fileName +
+											"\",\"contentType\":\"" + (string.IsNullOrEmpty(contentType) ? "b2/x-auto" : contentType) + "\"}";
+			var request = new HttpRequestMessage() {
+				Method = HttpMethod.Post,
+				RequestUri = uri,
+				Content = new StringContent(content),
+			};
 
-            request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
-            // File Info headers
-            if (fileInfo != null && fileInfo.Count > 0) {
-                foreach (var info in fileInfo.Take(10)) {
-                    request.Headers.Add($"X-Bz-Info-{info.Key}", info.Value);
-                }
-            }
-            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            request.Content.Headers.ContentLength = content.Length;
+			request.Headers.TryAddWithoutValidation("Authorization", options.AuthorizationToken);
+			// File Info headers
+			if (fileInfo != null && fileInfo.Count > 0) {
+				foreach (var info in fileInfo.Take(10)) {
+					request.Headers.Add($"X-Bz-Info-{info.Key}", info.Value);
+				}
+			}
+			request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+			request.Content.Headers.ContentLength = content.Length;
 
-            return request;
-        }
+			return request;
+		}
 
-        /// <summary>
-        /// Upload a file to B2. This method will calculate the SHA1 checksum before sending any data.
-        /// </summary>
-        /// <param name="options"></param>
-        /// <param name="uploadUrl"></param>
-        /// <param name="fileData"></param>
-        /// <param name="fileName"></param>
-        /// <param name="fileInfo"></param>
-        /// <returns></returns>
-        public static HttpRequestMessage Upload(B2Options options, byte[] fileData, int partNumber, B2UploadPartUrl uploadPartUrl) {
-            if (partNumber < 1 || partNumber > 10000) {
-                throw new Exception("Part number must be between 1 and 10,000");
-            }
+		/// <summary>
+		/// Upload a file to B2. This method will calculate the SHA1 checksum before sending any data.
+		/// </summary>
+		/// <param name="options"></param>
+		/// <param name="uploadUrl"></param>
+		/// <param name="fileData"></param>
+		/// <param name="fileName"></param>
+		/// <param name="fileInfo"></param>
+		/// <returns></returns>
+		public static HttpRequestMessage Upload(B2Options options, byte[] fileData, int partNumber, B2UploadPartUrl uploadPartUrl) {
+			if (partNumber < 1 || partNumber > 10000) {
+				throw new Exception("Part number must be between 1 and 10,000");
+			}
 
-            var uri = new Uri(uploadPartUrl.UploadUrl);
-            var request = new HttpRequestMessage() {
-                Method = HttpMethod.Post,
-                RequestUri = uri,
-                Content = new ByteArrayContent(fileData)
-            };
+			var uri = new Uri(uploadPartUrl.UploadUrl);
+			var request = new HttpRequestMessage() {
+				Method = HttpMethod.Post,
+				RequestUri = uri,
+				Content = new ByteArrayContent(fileData)
+			};
 
-            // Get the file checksum
-            string hash = Utilities.GetSHA1Hash(fileData);
+			// Get the file checksum
+			string hash = Utilities.GetSHA1Hash(fileData);
 
-            // Add headers
-            request.Headers.TryAddWithoutValidation("Authorization", uploadPartUrl.AuthorizationToken);
-            request.Headers.Add("X-Bz-Part-Number", partNumber.ToString());
-            request.Headers.Add("X-Bz-Content-Sha1", hash);
-            request.Content.Headers.ContentLength = fileData.Length;
+			// Add headers
+			request.Headers.TryAddWithoutValidation("Authorization", uploadPartUrl.AuthorizationToken);
+			request.Headers.Add("X-Bz-Part-Number", partNumber.ToString());
+			request.Headers.Add("X-Bz-Content-Sha1", hash);
+			request.Content.Headers.ContentLength = fileData.Length;
 
-            return request;
-        }
+			return request;
+		}
 
-        public static HttpRequestMessage GetUploadPartUrl(B2Options options, string fileId) {
-            return BaseRequestGenerator.PostRequest(Endpoints.GetPartUrl, JsonConvert.SerializeObject(new { fileId }), options);
-        }
+		public static HttpRequestMessage GetUploadPartUrl(B2Options options, string fileId) {
+			return BaseRequestGenerator.PostRequest(Endpoints.GetPartUrl, JsonConvert.SerializeObject(new { fileId }), options);
+		}
 
-        public static HttpRequestMessage Finish(B2Options options, string fileId, string[] partSHA1Array) {
-            var content = JsonConvert.SerializeObject(new { fileId, partSha1Array = partSHA1Array });
-            var request = BaseRequestGenerator.PostRequestJson(Endpoints.Finish, content, options);
-            return request;
-        }
+		public static HttpRequestMessage Finish(B2Options options, string fileId, string[] partSHA1Array) {
+			var content = JsonConvert.SerializeObject(new { fileId, partSha1Array = partSHA1Array });
+			var request = BaseRequestGenerator.PostRequestJson(Endpoints.Finish, content, options);
+			return request;
+		}
 
-        public static HttpRequestMessage ListParts(B2Options options, string fileId, int startPartNumber, int maxPartCount) {
-            if (startPartNumber < 1 || startPartNumber > 10000) {
-                throw new Exception("Start part number must be between 1 and 10,000");
-            }
-            
-            var content = JsonConvert.SerializeObject(new { fileId, startPartNumber, maxPartCount });
-            var request = BaseRequestGenerator.PostRequestJson(Endpoints.ListParts, content, options);
-            return request;
-        }
+		public static HttpRequestMessage ListParts(B2Options options, string fileId, int startPartNumber, int maxPartCount) {
+			if (startPartNumber < 1 || startPartNumber > 10000) {
+				throw new Exception("Start part number must be between 1 and 10,000");
+			}
 
-        public static HttpRequestMessage Cancel(B2Options options, string fileId) {
-            var content = JsonConvert.SerializeObject(new { fileId });
-            var request = BaseRequestGenerator.PostRequestJson(Endpoints.Cancel, content, options);
-            return request;
-        }
+			var content = JsonConvert.SerializeObject(new { fileId, startPartNumber, maxPartCount });
+			var request = BaseRequestGenerator.PostRequestJson(Endpoints.ListParts, content, options);
+			return request;
+		}
 
-        public static HttpRequestMessage IncompleteFiles(B2Options options, string bucketId, string startFileId = "", string maxFileCount = "") {
-            var body = "{\"bucketId\":\"" + bucketId + "\"";
-            if (!string.IsNullOrEmpty(startFileId)) {
-                body += ", \"startFileId\":" + JsonConvert.ToString(startFileId);
-            }
-            if (!string.IsNullOrEmpty(maxFileCount)) {
-                body += ", \"maxFileCount\":" + JsonConvert.ToString(maxFileCount);
-            }
-            body += "}";
-            var request = BaseRequestGenerator.PostRequestJson(Endpoints.IncompleteFiles, body, options);
-            return request;
-        }
-    }
+		public static HttpRequestMessage Cancel(B2Options options, string fileId) {
+			var content = JsonConvert.SerializeObject(new { fileId });
+			var request = BaseRequestGenerator.PostRequestJson(Endpoints.Cancel, content, options);
+			return request;
+		}
+
+		public static HttpRequestMessage IncompleteFiles(B2Options options, string bucketId, string startFileId = "", string maxFileCount = "") {
+			var body = "{\"bucketId\":\"" + bucketId + "\"";
+			if (!string.IsNullOrEmpty(startFileId)) {
+				body += ", \"startFileId\":" + JsonConvert.ToString(startFileId);
+			}
+			if (!string.IsNullOrEmpty(maxFileCount)) {
+				body += ", \"maxFileCount\":" + JsonConvert.ToString(maxFileCount);
+			}
+			body += "}";
+			var request = BaseRequestGenerator.PostRequestJson(Endpoints.IncompleteFiles, body, options);
+			return request;
+		}
+	}
 }

--- a/src/Http/ResponseParser.cs
+++ b/src/Http/ResponseParser.cs
@@ -1,6 +1,6 @@
-﻿using System.Net.Http;
+﻿using Newtonsoft.Json;
+using System.Net.Http;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace B2Net.Http {
 	public static class ResponseParser {
@@ -10,9 +10,9 @@ namespace B2Net.Http {
 			Utilities.CheckForErrors(response, callingApi);
 
 			var obj = JsonConvert.DeserializeObject<T>(jsonResponse, new JsonSerializerSettings() {
-                NullValueHandling = NullValueHandling.Ignore
-            });
-            return obj;
+				NullValueHandling = NullValueHandling.Ignore
+			});
+			return obj;
 		}
 	}
 }

--- a/src/IB2Client.cs
+++ b/src/IB2Client.cs
@@ -2,14 +2,12 @@
 using System.Threading.Tasks;
 using B2Net.Models;
 
-namespace B2Net
-{
-  public interface IB2Client
-  {
-    IBuckets Buckets { get; }
-    IFiles Files { get; }
-    ILargeFiles LargeFiles { get; }
+namespace B2Net {
+	public interface IB2Client {
+		IBuckets Buckets { get; }
+		IFiles Files { get; }
+		ILargeFiles LargeFiles { get; }
 
-    Task<B2Options> Authorize(CancellationToken cancelToken = default(CancellationToken));
-  }
+		Task<B2Options> Authorize(CancellationToken cancelToken = default(CancellationToken));
+	}
 }

--- a/src/IBuckets.cs
+++ b/src/IBuckets.cs
@@ -3,15 +3,13 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace B2Net
-{
-  public interface IBuckets
-  {
-    Task<B2Bucket> Create(string bucketName, B2BucketOptions options, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2Bucket> Create(string bucketName, BucketTypes bucketType, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2Bucket> Delete(string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<List<B2Bucket>> GetList(CancellationToken cancelToken = default(CancellationToken));
-    Task<B2Bucket> Update(B2BucketOptions options, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2Bucket> Update(BucketTypes bucketType, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
-  }
+namespace B2Net {
+	public interface IBuckets {
+		Task<B2Bucket> Create(string bucketName, B2BucketOptions options, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2Bucket> Create(string bucketName, BucketTypes bucketType, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2Bucket> Delete(string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<List<B2Bucket>> GetList(CancellationToken cancelToken = default(CancellationToken));
+		Task<B2Bucket> Update(B2BucketOptions options, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2Bucket> Update(BucketTypes bucketType, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+	}
 }

--- a/src/IFiles.cs
+++ b/src/IFiles.cs
@@ -3,26 +3,24 @@ using System.Threading;
 using System.Threading.Tasks;
 using B2Net.Models;
 
-namespace B2Net
-{
-  public interface IFiles
-  {
-    Task<B2File> Delete(string fileId, string fileName, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> DownloadById(string fileId, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> DownloadById(string fileId, int startByte, int endByte, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> DownloadByName(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2DownloadAuthorization> GetDownloadAuthorization(string fileNamePrefix, int validDurationInSeconds, string bucketId = "", string b2ContentDisposition = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> DownloadByName(string fileName, string bucketName, int startByte, int endByte, CancellationToken cancelToken = default(CancellationToken));
-    string GetFriendlyDownloadUrl(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> GetInfo(string fileId, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2FileList> GetList(string startFileName = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2FileList> GetListWithPrefixOrDemiliter(string startFileName = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2UploadUrl> GetUploadUrl(string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2FileList> GetVersions(string startFileName = "", string startFileId = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2FileList> GetVersionsWithPrefixOrDelimiter(string startFileName = "", string startFileId = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> Hide(string fileName, string bucketId = "", string fileId = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> Upload(byte[] fileData, string fileName, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, bool autoRetry, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
-  }
+namespace B2Net {
+	public interface IFiles {
+		Task<B2File> Delete(string fileId, string fileName, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> DownloadById(string fileId, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> DownloadById(string fileId, int startByte, int endByte, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> DownloadByName(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2DownloadAuthorization> GetDownloadAuthorization(string fileNamePrefix, int validDurationInSeconds, string bucketId = "", string b2ContentDisposition = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> DownloadByName(string fileName, string bucketName, int startByte, int endByte, CancellationToken cancelToken = default(CancellationToken));
+		string GetFriendlyDownloadUrl(string fileName, string bucketName, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> GetInfo(string fileId, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2FileList> GetList(string startFileName = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2FileList> GetListWithPrefixOrDemiliter(string startFileName = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2UploadUrl> GetUploadUrl(string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2FileList> GetVersions(string startFileName = "", string startFileId = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2FileList> GetVersionsWithPrefixOrDelimiter(string startFileName = "", string startFileId = "", string prefix = "", string delimiter = "", int? maxFileCount = null, string bucketId = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> Hide(string fileName, string bucketId = "", string fileId = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> Upload(byte[] fileData, string fileName, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> Upload(byte[] fileData, string fileName, B2UploadUrl uploadUrl, bool autoRetry, string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
+	}
 }

--- a/src/ILargeFiles.cs
+++ b/src/ILargeFiles.cs
@@ -3,16 +3,14 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace B2Net
-{
-  public interface ILargeFiles
-  {
-    Task<B2CancelledFile> CancelLargeFile(string fileId, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> FinishLargeFile(string fileId, string[] partSHA1Array, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2UploadPartUrl> GetUploadPartUrl(string fileId, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2IncompleteLargeFiles> ListIncompleteFiles(string bucketId, string startFileId = "", string maxFileCount = "", CancellationToken cancelToken = default(CancellationToken));
-    Task<B2LargeFileParts> ListPartsForIncompleteFile(string fileId, int startPartNumber, int maxPartCount, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2File> StartLargeFile(string fileName, string contentType = "", string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
-    Task<B2UploadPart> UploadPart(byte[] fileData, int partNumber, B2UploadPartUrl uploadPartUrl, CancellationToken cancelToken = default(CancellationToken));
-  }
+namespace B2Net {
+	public interface ILargeFiles {
+		Task<B2CancelledFile> CancelLargeFile(string fileId, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> FinishLargeFile(string fileId, string[] partSHA1Array, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2UploadPartUrl> GetUploadPartUrl(string fileId, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2IncompleteLargeFiles> ListIncompleteFiles(string bucketId, string startFileId = "", string maxFileCount = "", CancellationToken cancelToken = default(CancellationToken));
+		Task<B2LargeFileParts> ListPartsForIncompleteFile(string fileId, int startPartNumber, int maxPartCount, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2File> StartLargeFile(string fileName, string contentType = "", string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken));
+		Task<B2UploadPart> UploadPart(byte[] fileData, int partNumber, B2UploadPartUrl uploadPartUrl, CancellationToken cancelToken = default(CancellationToken));
+	}
 }

--- a/src/LargeFiles.cs
+++ b/src/LargeFiles.cs
@@ -6,10 +6,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace B2Net
-{
-  public class LargeFiles : ILargeFiles
-  {
+namespace B2Net {
+	public class LargeFiles : ILargeFiles {
 		private B2Options _options;
 		private HttpClient _client;
 		private string _api = "Large Files";
@@ -19,126 +17,126 @@ namespace B2Net
 			_client = HttpClientFactory.CreateHttpClient(options.RequestTimeout);
 		}
 
-        /// <summary>
-        /// Starts a large file upload.
-        /// </summary>
-        /// <param name="fileId"></param>
-        /// <param name="fileName"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2File> StartLargeFile(string fileName, string contentType = "", string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken)) {
-            var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
+		/// <summary>
+		/// Starts a large file upload.
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="fileName"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> StartLargeFile(string fileName, string contentType = "", string bucketId = "", Dictionary<string, string> fileInfo = null, CancellationToken cancelToken = default(CancellationToken)) {
+			var operationalBucketId = Utilities.DetermineBucketId(_options, bucketId);
 
-            var request = LargeFileRequestGenerators.Start(_options, operationalBucketId, fileName, contentType, fileInfo);
+			var request = LargeFileRequestGenerators.Start(_options, operationalBucketId, fileName, contentType, fileInfo);
 
-            // Send the download request
-            var response = await _client.SendAsync(request, cancelToken);
+			// Send the download request
+			var response = await _client.SendAsync(request, cancelToken);
 
-            // Create B2File from response
-            return await ResponseParser.ParseResponse<B2File>(response, _api);
-        }
+			// Create B2File from response
+			return await ResponseParser.ParseResponse<B2File>(response, _api);
+		}
 
-        /// <summary>
-        /// Get an upload url for use with one Thread.
-        /// </summary>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2UploadPartUrl> GetUploadPartUrl(string fileId, CancellationToken cancelToken = default(CancellationToken)) {
-            var request = LargeFileRequestGenerators.GetUploadPartUrl(_options, fileId);
+		/// <summary>
+		/// Get an upload url for use with one Thread.
+		/// </summary>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2UploadPartUrl> GetUploadPartUrl(string fileId, CancellationToken cancelToken = default(CancellationToken)) {
+			var request = LargeFileRequestGenerators.GetUploadPartUrl(_options, fileId);
 
-            var uploadUrlResponse = await _client.SendAsync(request, cancelToken);
+			var uploadUrlResponse = await _client.SendAsync(request, cancelToken);
 
-            var uploadUrl = await ResponseParser.ParseResponse<B2UploadPartUrl>(uploadUrlResponse, _api);
+			var uploadUrl = await ResponseParser.ParseResponse<B2UploadPartUrl>(uploadUrlResponse, _api);
 
-            return uploadUrl;
-        }
+			return uploadUrl;
+		}
 
-        /// <summary>
-        /// Upload one part of an already started large file upload.
-        /// </summary>
-        /// <param name="fileData"></param>
-        /// <param name="fileName"></param>
-        /// <param name="bucketId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-        public async Task<B2UploadPart> UploadPart(byte[] fileData, int partNumber, B2UploadPartUrl uploadPartUrl, CancellationToken cancelToken = default(CancellationToken)) {
-            var request = LargeFileRequestGenerators.Upload(_options, fileData, partNumber, uploadPartUrl);
+		/// <summary>
+		/// Upload one part of an already started large file upload.
+		/// </summary>
+		/// <param name="fileData"></param>
+		/// <param name="fileName"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2UploadPart> UploadPart(byte[] fileData, int partNumber, B2UploadPartUrl uploadPartUrl, CancellationToken cancelToken = default(CancellationToken)) {
+			var request = LargeFileRequestGenerators.Upload(_options, fileData, partNumber, uploadPartUrl);
 
-            var response = _client.SendAsync(request, cancelToken).Result;
-            
-            return await ResponseParser.ParseResponse<B2UploadPart>(response, _api);
-        }
+			var response = _client.SendAsync(request, cancelToken).Result;
 
-	    /// <summary>
-	    /// Downloads one file by providing the name of the bucket and the name of the file.
-	    /// </summary>
-	    /// <param name="fileId"></param>
-	    /// <param name="fileName"></param>
-	    /// <param name="bucketId"></param>
-	    /// <param name="cancelToken"></param>
-	    /// <returns></returns>
-	    public async Task<B2File> FinishLargeFile(string fileId, string[] partSHA1Array, CancellationToken cancelToken = default(CancellationToken)) {
-	        var request = LargeFileRequestGenerators.Finish(_options, fileId, partSHA1Array);
+			return await ResponseParser.ParseResponse<B2UploadPart>(response, _api);
+		}
 
-	        // Send the request
-	        var response = await _client.SendAsync(request, cancelToken);
+		/// <summary>
+		/// Downloads one file by providing the name of the bucket and the name of the file.
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="fileName"></param>
+		/// <param name="bucketId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2File> FinishLargeFile(string fileId, string[] partSHA1Array, CancellationToken cancelToken = default(CancellationToken)) {
+			var request = LargeFileRequestGenerators.Finish(_options, fileId, partSHA1Array);
 
-	        // Create B2File from response
-	        return await ResponseParser.ParseResponse<B2File>(response, _api);
-        }
+			// Send the request
+			var response = await _client.SendAsync(request, cancelToken);
 
-        /// <summary>
-        /// List the parts of an incomplete large file upload.
-        /// </summary>
-        /// <param name="fileId"></param>
-        /// <param name="startPartNumber"></param>
-        /// <param name="maxPartCount"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-	    public async Task<B2LargeFileParts> ListPartsForIncompleteFile(string fileId, int startPartNumber, int maxPartCount, CancellationToken cancelToken = default(CancellationToken)) {
-	        var request = LargeFileRequestGenerators.ListParts(_options, fileId, startPartNumber, maxPartCount);
+			// Create B2File from response
+			return await ResponseParser.ParseResponse<B2File>(response, _api);
+		}
 
-	        // Send the request
-	        var response = await _client.SendAsync(request, cancelToken);
+		/// <summary>
+		/// List the parts of an incomplete large file upload.
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="startPartNumber"></param>
+		/// <param name="maxPartCount"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2LargeFileParts> ListPartsForIncompleteFile(string fileId, int startPartNumber, int maxPartCount, CancellationToken cancelToken = default(CancellationToken)) {
+			var request = LargeFileRequestGenerators.ListParts(_options, fileId, startPartNumber, maxPartCount);
 
-	        // Create B2File from response
-	        return await ResponseParser.ParseResponse<B2LargeFileParts>(response, _api);
-	    }
-        
-        /// <summary>
-        /// Cancel a large file upload
-        /// </summary>
-        /// <param name="fileId"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-	    public async Task<B2CancelledFile> CancelLargeFile(string fileId, CancellationToken cancelToken = default(CancellationToken)) {
-	        var request = LargeFileRequestGenerators.Cancel(_options, fileId);
+			// Send the request
+			var response = await _client.SendAsync(request, cancelToken);
 
-	        // Send the request
-	        var response = await _client.SendAsync(request, cancelToken);
+			// Create B2File from response
+			return await ResponseParser.ParseResponse<B2LargeFileParts>(response, _api);
+		}
 
-	        // Create B2File from response
-	        return await ResponseParser.ParseResponse<B2CancelledFile>(response, _api);
-	    }
+		/// <summary>
+		/// Cancel a large file upload
+		/// </summary>
+		/// <param name="fileId"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2CancelledFile> CancelLargeFile(string fileId, CancellationToken cancelToken = default(CancellationToken)) {
+			var request = LargeFileRequestGenerators.Cancel(_options, fileId);
 
-        /// <summary>
-        /// List all the incomplete large file uploads for the supplied bucket
-        /// </summary>
-        /// <param name="bucketId"></param>
-        /// <param name="startFileId"></param>
-        /// <param name="maxFileCount"></param>
-        /// <param name="cancelToken"></param>
-        /// <returns></returns>
-	    public async Task<B2IncompleteLargeFiles> ListIncompleteFiles(string bucketId, string startFileId = "", string maxFileCount = "", CancellationToken cancelToken = default(CancellationToken)) {
-	        var request = LargeFileRequestGenerators.IncompleteFiles(_options, bucketId, startFileId, maxFileCount);
+			// Send the request
+			var response = await _client.SendAsync(request, cancelToken);
 
-	        // Send the request
-	        var response = await _client.SendAsync(request, cancelToken);
+			// Create B2File from response
+			return await ResponseParser.ParseResponse<B2CancelledFile>(response, _api);
+		}
 
-	        // Create B2File from response
-	        return await ResponseParser.ParseResponse<B2IncompleteLargeFiles>(response, _api);
-	    }
-    }
+		/// <summary>
+		/// List all the incomplete large file uploads for the supplied bucket
+		/// </summary>
+		/// <param name="bucketId"></param>
+		/// <param name="startFileId"></param>
+		/// <param name="maxFileCount"></param>
+		/// <param name="cancelToken"></param>
+		/// <returns></returns>
+		public async Task<B2IncompleteLargeFiles> ListIncompleteFiles(string bucketId, string startFileId = "", string maxFileCount = "", CancellationToken cancelToken = default(CancellationToken)) {
+			var request = LargeFileRequestGenerators.IncompleteFiles(_options, bucketId, startFileId, maxFileCount);
+
+			// Send the request
+			var response = await _client.SendAsync(request, cancelToken);
+
+			// Create B2File from response
+			return await ResponseParser.ParseResponse<B2IncompleteLargeFiles>(response, _api);
+		}
+	}
 }

--- a/src/Models/B2AuthResponse.cs
+++ b/src/Models/B2AuthResponse.cs
@@ -1,16 +1,14 @@
-﻿using System.Collections.Generic;
-
-namespace B2Net.Models {
+﻿namespace B2Net.Models {
 	public class B2AuthResponse {
 		public string accountId { get; set; }
 		public string apiUrl { get; set; }
 		public string authorizationToken { get; set; }
 		public string downloadUrl { get; set; }
-        public long recommendedPartSize { get; set; }
-        public long absoluteMinimumPartSize { get; set; }
-        public long minimumPartSize { get; set; }
+		public long recommendedPartSize { get; set; }
+		public long absoluteMinimumPartSize { get; set; }
+		public long minimumPartSize { get; set; }
 		public B2AuthCapabilities allowed { get; set; }
-    }
+	}
 
 	public class B2AuthCapabilities {
 		public string bucketId { get; set; }

--- a/src/Models/B2Bucket.cs
+++ b/src/Models/B2Bucket.cs
@@ -5,16 +5,15 @@ namespace B2Net.Models {
 		public string BucketId { get; set; }
 		public string BucketName { get; set; }
 		public string BucketType { get; set; }
-        public Dictionary<string,string> BucketInfo { get; set; }
-        public List<B2BucketLifecycleRule> LifecycleRules { get; set; }
-    }
+		public Dictionary<string, string> BucketInfo { get; set; }
+		public List<B2BucketLifecycleRule> LifecycleRules { get; set; }
+	}
 
-    public class B2BucketLifecycleRule
-    {
-        public int? DaysFromHidingToDeleting { get; set; }
-        public int? DaysFromUploadingToHiding { get; set; }
-        public string FileNamePrefix { get; set; }
-    }
+	public class B2BucketLifecycleRule {
+		public int? DaysFromHidingToDeleting { get; set; }
+		public int? DaysFromUploadingToHiding { get; set; }
+		public string FileNamePrefix { get; set; }
+	}
 
 	public class B2BucketListDeserializeModel {
 		public List<B2Bucket> Buckets { get; set; }

--- a/src/Models/B2BucketOptions.cs
+++ b/src/Models/B2BucketOptions.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
-namespace B2Net.Models
-{
-    public class B2BucketOptions
-    {
-        public BucketTypes BucketType { get; set; } = BucketTypes.allPrivate;
-        public int CacheControl { get; set; }
-        public List<B2BucketLifecycleRule> LifecycleRules { get; set; }
-    }
+namespace B2Net.Models {
+	public class B2BucketOptions {
+		public BucketTypes BucketType { get; set; } = BucketTypes.allPrivate;
+		public int CacheControl { get; set; }
+		public List<B2BucketLifecycleRule> LifecycleRules { get; set; }
+	}
 }

--- a/src/Models/B2Capabilities.cs
+++ b/src/Models/B2Capabilities.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace B2Net.Models
-{
-    public class B2Capabilities
-    {
-	    public string BucketName { get; set; }
-	    public string BucketId { get; set; }
-	    public string NamePrefix { get; set; }
-	    public string[] Capabilities { get; set; }
-    }
+﻿namespace B2Net.Models {
+	public class B2Capabilities {
+		public string BucketName { get; set; }
+		public string BucketId { get; set; }
+		public string NamePrefix { get; set; }
+		public string[] Capabilities { get; set; }
+	}
 }

--- a/src/Models/B2DownloadAuthorization.cs
+++ b/src/Models/B2DownloadAuthorization.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace B2Net.Models
-{
-    public class B2DownloadAuthorization
-    {
-	    public string BucketId { get; set; }
-	    public string FileNamePrefix { get; set; }
-	    public string AuthorizationToken { get; set; }
-    }
+﻿namespace B2Net.Models {
+	public class B2DownloadAuthorization {
+		public string BucketId { get; set; }
+		public string FileNamePrefix { get; set; }
+		public string AuthorizationToken { get; set; }
+	}
 }

--- a/src/Models/B2File.cs
+++ b/src/Models/B2File.cs
@@ -13,17 +13,16 @@ namespace B2Net.Models {
 		public string ContentLength { get; set; }
 		public string ContentSHA1 { get; set; }
 		public string ContentType { get; set; }
-		public Dictionary<string,string> FileInfo { get; set; }
+		public Dictionary<string, string> FileInfo { get; set; }
 		// End
 
-		public DateTime UploadTimestampDate
-		{
-			get
-			{
+		public DateTime UploadTimestampDate {
+			get {
 				if (!string.IsNullOrEmpty(UploadTimestamp)) {
 					var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 					return epoch.AddMilliseconds(double.Parse(UploadTimestamp));
-				} else {
+				}
+				else {
 					return DateTime.Now;
 				}
 			}

--- a/src/Models/B2LargeFiles.cs
+++ b/src/Models/B2LargeFiles.cs
@@ -1,46 +1,43 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
-namespace B2Net.Models
-{
-    public class B2UploadPartUrl {
-        public string FileId { get; set; }
-        public string UploadUrl { get; set; }
-        public string AuthorizationToken { get; set; }
-    }
+namespace B2Net.Models {
+	public class B2UploadPartUrl {
+		public string FileId { get; set; }
+		public string UploadUrl { get; set; }
+		public string AuthorizationToken { get; set; }
+	}
 
-    public class B2UploadPart {
-        public string FileId { get; set; }
-        public int PartNumber { get; set; }
-        public int Length => ContentLength;
-        public string SHA1 => ContentSHA1;
-        public int ContentLength { get; set; }
-        public string ContentSHA1 { get; set; }
-    }
+	public class B2UploadPart {
+		public string FileId { get; set; }
+		public int PartNumber { get; set; }
+		public int Length => ContentLength;
+		public string SHA1 => ContentSHA1;
+		public int ContentLength { get; set; }
+		public string ContentSHA1 { get; set; }
+	}
 
-    public class B2LargeFileParts {
-        public int NextPartNumber { get; set; }
-        public List<B2LargeFilePart> Parts { get; set; }
-    }
+	public class B2LargeFileParts {
+		public int NextPartNumber { get; set; }
+		public List<B2LargeFilePart> Parts { get; set; }
+	}
 
-    public class B2LargeFilePart {
-        public string FileId { get; set; }
-        public int PartNumber { get; set; }
-        public string ContentLength { get; set; }
-        public string ContentSha1 { get; set; }
-        public string UploadTimestamp { get; set; }
-    }
+	public class B2LargeFilePart {
+		public string FileId { get; set; }
+		public int PartNumber { get; set; }
+		public string ContentLength { get; set; }
+		public string ContentSha1 { get; set; }
+		public string UploadTimestamp { get; set; }
+	}
 
-    public class B2CancelledFile {
-        public string FileId { get; set; }
-        public string AccountId { get; set; }
-        public string BucketId { get; set; }
-        public string FileName { get; set; }
-    }
+	public class B2CancelledFile {
+		public string FileId { get; set; }
+		public string AccountId { get; set; }
+		public string BucketId { get; set; }
+		public string FileName { get; set; }
+	}
 
-    public class B2IncompleteLargeFiles {
-        public string NextFileId { get; set; }
-        public List<B2File> Files { get; set; }
-    }
+	public class B2IncompleteLargeFiles {
+		public string NextFileId { get; set; }
+		public List<B2File> Files { get; set; }
+	}
 }

--- a/src/Models/B2Options.cs
+++ b/src/Models/B2Options.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace B2Net.Models {
+﻿namespace B2Net.Models {
 	public class B2Options {
 		public string AccountId { get; set; }
 		public string KeyId { get; set; }
@@ -13,8 +11,8 @@ namespace B2Net.Models {
 		/// </summary>
 		public bool PersistBucket { get; set; }
 
-        // State
-        public string ApiUrl { get; set; }
+		// State
+		public string ApiUrl { get; set; }
 		public string DownloadUrl { get; set; }
 		public string AuthorizationToken { get; set; }
 		public B2Capabilities Capabilities { get; set; }
@@ -22,8 +20,8 @@ namespace B2Net.Models {
 		/// This will only be set after a call to the upload API
 		/// </summary>
 		public string UploadAuthorizationToken { get; set; }
-        public long RecommendedPartSize { get; set; }
-        public long AbsoluteMinimumPartSize { get; set; }
+		public long RecommendedPartSize { get; set; }
+		public long AbsoluteMinimumPartSize { get; set; }
 
 		/// <summary>
 		/// Deprecated: Will always be the same as RecommendedPartSize
@@ -32,19 +30,19 @@ namespace B2Net.Models {
 			get { return RecommendedPartSize; }
 		}
 
-	    public int RequestTimeout { get; set; }
+		public int RequestTimeout { get; set; }
 
-        public B2Options() {
+		public B2Options() {
 			PersistBucket = false;
-            RequestTimeout = 100;
-        }
+			RequestTimeout = 100;
+		}
 
 		public void SetState(B2AuthResponse response) {
 			ApiUrl = response.apiUrl;
 			DownloadUrl = response.downloadUrl;
 			AuthorizationToken = response.authorizationToken;
-            RecommendedPartSize = response.recommendedPartSize;
-            AbsoluteMinimumPartSize = response.absoluteMinimumPartSize;
+			RecommendedPartSize = response.recommendedPartSize;
+			AbsoluteMinimumPartSize = response.absoluteMinimumPartSize;
 			Capabilities = new B2Capabilities() {
 				BucketId = response.allowed.bucketId,
 				BucketName = response.allowed.bucketName,

--- a/src/Models/B2UploadUrl.cs
+++ b/src/Models/B2UploadUrl.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace B2Net.Models {
-    public class B2UploadUrl {
-        public string BucketId { get; set; }
-        public string UploadUrl { get; set; }
-        public string AuthorizationToken { get; set; }
-    }
+﻿namespace B2Net.Models {
+	public class B2UploadUrl {
+		public string BucketId { get; set; }
+		public string UploadUrl { get; set; }
+		public string AuthorizationToken { get; set; }
+	}
 }

--- a/src/Models/Exceptions.cs
+++ b/src/Models/Exceptions.cs
@@ -6,14 +6,14 @@ namespace B2Net.Models {
 	}
 
 	public class B2Exception : Exception {
-        public string Status { get; set; }
-        public string Code { get; set; }
-        public bool ShouldRetryRequest { get; set; }
+		public string Status { get; set; }
+		public string Code { get; set; }
+		public bool ShouldRetryRequest { get; set; }
 
-        public B2Exception(string code, string status, string message, bool shouldRetry) : base(message) {
-            Status = status;
-            Code = code;
-            ShouldRetryRequest = shouldRetry;
-        }
-    }
+		public B2Exception(string code, string status, string message, bool shouldRetry) : base(message) {
+			Status = status;
+			Code = code;
+			ShouldRetryRequest = shouldRetry;
+		}
+	}
 }

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -16,20 +16,21 @@ namespace B2Net {
 			var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes(accountId + ":" + applicationKey));
 			return authHeader + credentials;
 		}
-		
+
 		public static void CheckForErrors(HttpResponseMessage response, string callingApi = "") {
 			if (!response.IsSuccessStatusCode) {
-                // Should retry
-			    bool retry = response.StatusCode == (HttpStatusCode) 429 ||
-			        response.StatusCode == HttpStatusCode.RequestTimeout ||
-			        response.StatusCode == HttpStatusCode.ServiceUnavailable;
+				// Should retry
+				bool retry = response.StatusCode == (HttpStatusCode)429 ||
+					response.StatusCode == HttpStatusCode.RequestTimeout ||
+					response.StatusCode == HttpStatusCode.ServiceUnavailable;
 
-                string content = response.Content.ReadAsStringAsync().Result;
+				string content = response.Content.ReadAsStringAsync().Result;
 
 				B2Error b2Error;
 				try {
 					b2Error = JsonConvert.DeserializeObject<B2Error>(content);
-				} catch (Exception ex) {
+				}
+				catch (Exception ex) {
 					throw new Exception("Seralization of the response failed. See inner exception for response contents and serialization error.", ex);
 				}
 				if (b2Error != null) {
@@ -53,7 +54,7 @@ namespace B2Net {
 			if (!options.PersistBucket && string.IsNullOrEmpty(bucketId)) {
 				throw new ArgumentNullException(nameof(bucketId));
 			}
-			
+
 			// Are we persisting buckets? If so use the one from settings
 			return options.PersistBucket ? options.BucketId : bucketId;
 		}

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using B2Net.Models;
+using Newtonsoft.Json;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
-using B2Net.Models;
-using Newtonsoft.Json;
 
 namespace B2Net {
 	public static class Utilities {

--- a/tests/AuthorizeTest.cs
+++ b/tests/AuthorizeTest.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.IO;
-using System.Net;
-using System.Security.Cryptography;
-using System.Text;
-using B2Net;
+﻿using B2Net;
 using B2Net.Models;
 using B2Net.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 
 namespace B2.Net.Tests {
 	[TestClass]
@@ -16,12 +10,12 @@ namespace B2.Net.Tests {
 		string applicationKeyId = "00151189a8b4c7a0000000005";
 
 		[TestMethod]
-	    public void CanWeAuthorize() {
-	        var client = new B2Client(Options);
+		public void CanWeAuthorize() {
+			var client = new B2Client(Options);
 
-	        var result = client.Authorize().Result;
+			var result = client.Authorize().Result;
 
-	        Assert.IsFalse(string.IsNullOrEmpty(result.AuthorizationToken));
+			Assert.IsFalse(string.IsNullOrEmpty(result.AuthorizationToken));
 		}
 
 		[TestMethod]
@@ -57,14 +51,14 @@ namespace B2.Net.Tests {
 		}
 
 		[TestMethod]
-        public void DoWeGetOptionsBack() {
-            var result = B2Client.Authorize(Options);
+		public void DoWeGetOptionsBack() {
+			var result = B2Client.Authorize(Options);
 
-            Assert.AreNotEqual("0", result.AbsoluteMinimumPartSize);
-            Assert.AreNotEqual("0", result.MinimumPartSize);
-            Assert.AreNotEqual("0", result.RecommendedPartSize);
-            Assert.IsFalse(string.IsNullOrEmpty(result.DownloadUrl));
-            Assert.IsFalse(string.IsNullOrEmpty(result.ApiUrl));
-        }
-    }
+			Assert.AreNotEqual("0", result.AbsoluteMinimumPartSize);
+			Assert.AreNotEqual("0", result.MinimumPartSize);
+			Assert.AreNotEqual("0", result.RecommendedPartSize);
+			Assert.IsFalse(string.IsNullOrEmpty(result.DownloadUrl));
+			Assert.IsFalse(string.IsNullOrEmpty(result.ApiUrl));
+		}
+	}
 }

--- a/tests/BaseTest.cs
+++ b/tests/BaseTest.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using B2.Net.Tests;
-using B2Net.Models;
+﻿using B2Net.Models;
 
 namespace B2Net.Tests {
 	public class BaseTest {

--- a/tests/BucketRestrictedTests.cs
+++ b/tests/BucketRestrictedTests.cs
@@ -1,28 +1,24 @@
-﻿using System;
-using System.IO;
-using B2Net.Http;
+﻿using B2Net.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using B2Net.Models;
-using System.Linq;
+using System.IO;
 using System.Threading.Tasks;
-using B2.Net.Tests;
 
 namespace B2Net.Tests {
 	[TestClass]
 	public class BucketRestrictedTests : BaseTest {
 		private string RestrictedBucketName = "B2Net-Test";
 		private string BucketName = "";
-		
-        [TestMethod]
+
+		[TestMethod]
 		[ExpectedException(typeof(B2Exception), "Unauthorized error when operating on Buckets. Are you sure the key you are using has access? ")]
 		public async Task GetBucketListTest() {
 			// Key that is restricted to RestrictedBucketName above.
-	        var client = new B2Client(B2Client.Authorize(new B2Options() {
-		        AccountId = TestConstants.AccountId,
-		        KeyId = "00151189a8b4c7a0000000006",
-		        ApplicationKey = "K001+GGkBNcbJVj3LD4+e3s5pCUMQ7U"
-	        }));
-	        BucketName = $"B2NETTestingBucket-{Path.GetRandomFileName().Replace(".", "").Substring(0, 6)}";
+			var client = new B2Client(B2Client.Authorize(new B2Options() {
+				AccountId = TestConstants.AccountId,
+				KeyId = "00151189a8b4c7a0000000006",
+				ApplicationKey = "K001+GGkBNcbJVj3LD4+e3s5pCUMQ7U"
+			}));
+			BucketName = $"B2NETTestingBucket-{Path.GetRandomFileName().Replace(".", "").Substring(0, 6)}";
 
 			var bucket = await client.Buckets.Create(BucketName, BucketTypes.allPrivate);
 		}

--- a/tests/BucketTests.cs
+++ b/tests/BucketTests.cs
@@ -1,23 +1,22 @@
-﻿using System;
-using System.IO;
-using B2Net.Http;
+﻿using B2Net.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using B2Net.Models;
+using System;
+using System.IO;
 using System.Linq;
 
 namespace B2Net.Tests {
 	[TestClass]
 	public class BucketTests : BaseTest {
-	    private B2Client Client = null;
-	    private string BucketName = "";
+		private B2Client Client = null;
+		private string BucketName = "";
 
-        [TestInitialize]
-	    public void Initialize() {
-	        Client = new B2Client(B2Client.Authorize(Options));
-            BucketName = $"B2NETTestingBucket-{Path.GetRandomFileName().Replace(".", "").Substring(0, 6)}";
-        }
+		[TestInitialize]
+		public void Initialize() {
+			Client = new B2Client(B2Client.Authorize(Options));
+			BucketName = $"B2NETTestingBucket-{Path.GetRandomFileName().Replace(".", "").Substring(0, 6)}";
+		}
 
-        [TestMethod]
+		[TestMethod]
 		public void GetBucketListTest() {
 			var bucket = Client.Buckets.Create(BucketName, BucketTypes.allPrivate).Result;
 
@@ -29,141 +28,140 @@ namespace B2Net.Tests {
 		}
 
 		[TestMethod]
-	    public void CreateBucketTest() {
-	        var bucket = Client.Buckets.Create(BucketName, BucketTypes.allPrivate).Result;
+		public void CreateBucketTest() {
+			var bucket = Client.Buckets.Create(BucketName, BucketTypes.allPrivate).Result;
 
-	        // Clean up
-	        if (!string.IsNullOrEmpty(bucket.BucketId)) {
-	            Client.Buckets.Delete(bucket.BucketId).Wait();
-	        }
+			// Clean up
+			if (!string.IsNullOrEmpty(bucket.BucketId)) {
+				Client.Buckets.Delete(bucket.BucketId).Wait();
+			}
 
-	        Assert.AreEqual(BucketName, bucket.BucketName);
-	    }
+			Assert.AreEqual(BucketName, bucket.BucketName);
+		}
 
-	    [TestMethod]
-        [ExpectedException(typeof(AggregateException))]
-	    public void CreateBucketInvalidNameTest() {
-	        var name = "B2net-testing-bucket-%$";
+		[TestMethod]
+		[ExpectedException(typeof(AggregateException))]
+		public void CreateBucketInvalidNameTest() {
+			var name = "B2net-testing-bucket-%$";
 
-	        var bucket = Client.Buckets.Create(name, BucketTypes.allPrivate).Result;
-	    }
+			var bucket = Client.Buckets.Create(name, BucketTypes.allPrivate).Result;
+		}
 
-        [TestMethod]
-        public void CreateBucketWithCacheControlTest() {
-            var bucket = Client.Buckets.Create(BucketName, new B2BucketOptions() {
-                CacheControl = 600
-            }).Result;
+		[TestMethod]
+		public void CreateBucketWithCacheControlTest() {
+			var bucket = Client.Buckets.Create(BucketName, new B2BucketOptions() {
+				CacheControl = 600
+			}).Result;
 
-            // Get bucket to check for info
-            var bucketList = Client.Buckets.GetList().Result;
+			// Get bucket to check for info
+			var bucketList = Client.Buckets.GetList().Result;
 
-            // Clean up
-            if (!string.IsNullOrEmpty(bucket.BucketId))
-            {
-                Client.Buckets.Delete(bucket.BucketId).Wait();
-            }
+			// Clean up
+			if (!string.IsNullOrEmpty(bucket.BucketId)) {
+				Client.Buckets.Delete(bucket.BucketId).Wait();
+			}
 
-            B2Bucket savedBucket = bucketList.FirstOrDefault(b => b.BucketName == bucket.BucketName);
+			B2Bucket savedBucket = bucketList.FirstOrDefault(b => b.BucketName == bucket.BucketName);
 
-            Assert.IsNotNull(savedBucket, "Retreived bucket was null");
-            Assert.IsNotNull(savedBucket.BucketInfo, "Bucekt info was null");
-            Assert.IsTrue(savedBucket.BucketInfo.ContainsKey("cache-control"), "Bucket info did not contain Cache-Control");
-            Assert.AreEqual("max-age=600", savedBucket.BucketInfo["cache-control"], "Cache-Control values were not equal.");
-        }
+			Assert.IsNotNull(savedBucket, "Retreived bucket was null");
+			Assert.IsNotNull(savedBucket.BucketInfo, "Bucekt info was null");
+			Assert.IsTrue(savedBucket.BucketInfo.ContainsKey("cache-control"), "Bucket info did not contain Cache-Control");
+			Assert.AreEqual("max-age=600", savedBucket.BucketInfo["cache-control"], "Cache-Control values were not equal.");
+		}
 
-        [TestMethod]
-        public void CreateBucketWithLifecycleRulesTest() {
-            var bucket = Client.Buckets.Create(BucketName, new B2BucketOptions() {
-                LifecycleRules = new System.Collections.Generic.List<B2BucketLifecycleRule>() {
-                    new B2BucketLifecycleRule() {
-                        DaysFromHidingToDeleting = 30,
-                        DaysFromUploadingToHiding = null,
-                        FileNamePrefix = "testing"
-                    }
-                }
-            }).Result;
+		[TestMethod]
+		public void CreateBucketWithLifecycleRulesTest() {
+			var bucket = Client.Buckets.Create(BucketName, new B2BucketOptions() {
+				LifecycleRules = new System.Collections.Generic.List<B2BucketLifecycleRule>() {
+					new B2BucketLifecycleRule() {
+						DaysFromHidingToDeleting = 30,
+						DaysFromUploadingToHiding = null,
+						FileNamePrefix = "testing"
+					}
+				}
+			}).Result;
 
-            // Get bucket to check for info
-            var bucketList = Client.Buckets.GetList().Result;
+			// Get bucket to check for info
+			var bucketList = Client.Buckets.GetList().Result;
 
-            // Clean up
-            if (!string.IsNullOrEmpty(bucket.BucketId)) {
-                Client.Buckets.Delete(bucket.BucketId).Wait();
-            }
+			// Clean up
+			if (!string.IsNullOrEmpty(bucket.BucketId)) {
+				Client.Buckets.Delete(bucket.BucketId).Wait();
+			}
 
-            var savedBucket = bucketList.FirstOrDefault(b => b.BucketName == bucket.BucketName);
+			var savedBucket = bucketList.FirstOrDefault(b => b.BucketName == bucket.BucketName);
 
-            Assert.IsNotNull(savedBucket, "Retreived bucket was null");
-            Assert.IsNotNull(savedBucket.BucketInfo, "Bucekt info was null");
-            Assert.AreEqual(savedBucket.LifecycleRules.Count, 1, "Lifecycle rules count was " + savedBucket.LifecycleRules.Count);
-            Assert.AreEqual("testing", savedBucket.LifecycleRules.First().FileNamePrefix, "File name prefixes in the first lifecycle rule were not equal.");
-            Assert.AreEqual(null, savedBucket.LifecycleRules.First().DaysFromUploadingToHiding, "The first lifecycle rule DaysFromUploadingToHiding was not null");
-            Assert.AreEqual(30, savedBucket.LifecycleRules.First().DaysFromHidingToDeleting, "The first lifecycle rule DaysFromHidingToDeleting was not 30");
-        }
+			Assert.IsNotNull(savedBucket, "Retreived bucket was null");
+			Assert.IsNotNull(savedBucket.BucketInfo, "Bucekt info was null");
+			Assert.AreEqual(savedBucket.LifecycleRules.Count, 1, "Lifecycle rules count was " + savedBucket.LifecycleRules.Count);
+			Assert.AreEqual("testing", savedBucket.LifecycleRules.First().FileNamePrefix, "File name prefixes in the first lifecycle rule were not equal.");
+			Assert.AreEqual(null, savedBucket.LifecycleRules.First().DaysFromUploadingToHiding, "The first lifecycle rule DaysFromUploadingToHiding was not null");
+			Assert.AreEqual(30, savedBucket.LifecycleRules.First().DaysFromHidingToDeleting, "The first lifecycle rule DaysFromHidingToDeleting was not 30");
+		}
 
-        [TestMethod]
-        public void UpdateBucketWithCacheControlTest() {
-            var bucket = Client.Buckets.Create(BucketName, new B2BucketOptions() { CacheControl = 600 }).Result;
+		[TestMethod]
+		public void UpdateBucketWithCacheControlTest() {
+			var bucket = Client.Buckets.Create(BucketName, new B2BucketOptions() { CacheControl = 600 }).Result;
 
-            // Update bucket with new info
-            bucket = Client.Buckets.Update(new B2BucketOptions() { CacheControl = 300 }, bucket.BucketId).Result;
+			// Update bucket with new info
+			bucket = Client.Buckets.Update(new B2BucketOptions() { CacheControl = 300 }, bucket.BucketId).Result;
 
-            // Get bucket to check for info
-            var bucketList = Client.Buckets.GetList().Result;
+			// Get bucket to check for info
+			var bucketList = Client.Buckets.GetList().Result;
 
-            // Clean up
-            if (!string.IsNullOrEmpty(bucket.BucketId)) {
-                Client.Buckets.Delete(bucket.BucketId).Wait();
-            }
+			// Clean up
+			if (!string.IsNullOrEmpty(bucket.BucketId)) {
+				Client.Buckets.Delete(bucket.BucketId).Wait();
+			}
 
-            var savedBucket = bucketList.FirstOrDefault(b => b.BucketName == bucket.BucketName);
+			var savedBucket = bucketList.FirstOrDefault(b => b.BucketName == bucket.BucketName);
 
-            Assert.IsNotNull(savedBucket, "Retreived bucket was null");
-            Assert.IsNotNull(savedBucket.BucketInfo, "Bucekt info was null");
-            Assert.IsTrue(savedBucket.BucketInfo.ContainsKey("cache-control"), "Bucket info did not contain Cache-Control");
-            Assert.AreEqual("max-age=300", savedBucket.BucketInfo["cache-control"], "Cache-Control values were not equal.");
-        }
+			Assert.IsNotNull(savedBucket, "Retreived bucket was null");
+			Assert.IsNotNull(savedBucket.BucketInfo, "Bucekt info was null");
+			Assert.IsTrue(savedBucket.BucketInfo.ContainsKey("cache-control"), "Bucket info did not contain Cache-Control");
+			Assert.AreEqual("max-age=300", savedBucket.BucketInfo["cache-control"], "Cache-Control values were not equal.");
+		}
 
-        [TestMethod]
-        public void UpdateBucketWithLifecycleRulesTest() {
-            var bucket = Client.Buckets.Create(BucketName, new B2BucketOptions() {
-                LifecycleRules = new System.Collections.Generic.List<B2BucketLifecycleRule>() {
-                    new B2BucketLifecycleRule() {
-                        DaysFromHidingToDeleting = 30,
-                        DaysFromUploadingToHiding = 15,
-                        FileNamePrefix = "testing"
-                    }
-                }
-            }).Result;
+		[TestMethod]
+		public void UpdateBucketWithLifecycleRulesTest() {
+			var bucket = Client.Buckets.Create(BucketName, new B2BucketOptions() {
+				LifecycleRules = new System.Collections.Generic.List<B2BucketLifecycleRule>() {
+					new B2BucketLifecycleRule() {
+						DaysFromHidingToDeleting = 30,
+						DaysFromUploadingToHiding = 15,
+						FileNamePrefix = "testing"
+					}
+				}
+			}).Result;
 
-            // Update bucket with new info
-            bucket = Client.Buckets.Update(new B2BucketOptions() {
-                LifecycleRules = new System.Collections.Generic.List<B2BucketLifecycleRule>() {
-                    new B2BucketLifecycleRule() {
-                        DaysFromHidingToDeleting = 10,
-                        DaysFromUploadingToHiding = 10,
-                        FileNamePrefix = "tested"
-                    }
-                }
-            }, bucket.BucketId).Result;
+			// Update bucket with new info
+			bucket = Client.Buckets.Update(new B2BucketOptions() {
+				LifecycleRules = new System.Collections.Generic.List<B2BucketLifecycleRule>() {
+					new B2BucketLifecycleRule() {
+						DaysFromHidingToDeleting = 10,
+						DaysFromUploadingToHiding = 10,
+						FileNamePrefix = "tested"
+					}
+				}
+			}, bucket.BucketId).Result;
 
-            // Get bucket to check for info
-            var bucketList = Client.Buckets.GetList().Result;
+			// Get bucket to check for info
+			var bucketList = Client.Buckets.GetList().Result;
 
-            // Clean up
-            if (!string.IsNullOrEmpty(bucket.BucketId)) {
-                Client.Buckets.Delete(bucket.BucketId).Wait();
-            }
+			// Clean up
+			if (!string.IsNullOrEmpty(bucket.BucketId)) {
+				Client.Buckets.Delete(bucket.BucketId).Wait();
+			}
 
-            var savedBucket = bucketList.FirstOrDefault(b => b.BucketName == bucket.BucketName);
+			var savedBucket = bucketList.FirstOrDefault(b => b.BucketName == bucket.BucketName);
 
-            Assert.IsNotNull(savedBucket, "Retreived bucket was null");
-            Assert.IsNotNull(savedBucket.BucketInfo, "Bucekt info was null");
-            Assert.AreEqual(savedBucket.LifecycleRules.Count, 1, "Lifecycle rules count was " + savedBucket.LifecycleRules.Count);
-            Assert.AreEqual("tested", savedBucket.LifecycleRules.First().FileNamePrefix, "File name prefixes in the first lifecycle rule were not equal.");
-        }
+			Assert.IsNotNull(savedBucket, "Retreived bucket was null");
+			Assert.IsNotNull(savedBucket.BucketInfo, "Bucekt info was null");
+			Assert.AreEqual(savedBucket.LifecycleRules.Count, 1, "Lifecycle rules count was " + savedBucket.LifecycleRules.Count);
+			Assert.AreEqual("tested", savedBucket.LifecycleRules.First().FileNamePrefix, "File name prefixes in the first lifecycle rule were not equal.");
+		}
 
-        [TestMethod]
+		[TestMethod]
 		public void DeleteBucketTest() {
 			//Creat a bucket to delete
 			var bucket = Client.Buckets.Create(BucketName, BucketTypes.allPrivate).Result;
@@ -171,7 +169,8 @@ namespace B2Net.Tests {
 			if (!string.IsNullOrEmpty(bucket.BucketId)) {
 				var deletedBucket = Client.Buckets.Delete(bucket.BucketId).Result;
 				Assert.AreEqual(BucketName, deletedBucket.BucketName);
-			} else {
+			}
+			else {
 				Assert.Fail("The bucket was not deleted. The response did not contain a bucketid.");
 			}
 		}
@@ -185,13 +184,16 @@ namespace B2Net.Tests {
 				if (!string.IsNullOrEmpty(bucket.BucketId)) {
 					var updatedBucket = Client.Buckets.Update(BucketTypes.allPublic, bucket.BucketId).Result;
 					Assert.AreEqual(BucketTypes.allPublic.ToString(), updatedBucket.BucketType);
-				} else {
+				}
+				else {
 					Assert.Fail("The bucket was not deleted. The response did not contain a bucketid.");
 				}
-			} catch (Exception ex) {
+			}
+			catch (Exception ex) {
 				Assert.Fail(ex.Message);
-			} finally {
-			    Client.Buckets.Delete(bucket.BucketId).Wait();
+			}
+			finally {
+				Client.Buckets.Delete(bucket.BucketId).Wait();
 			}
 		}
 	}

--- a/tests/FileTests.cs
+++ b/tests/FileTests.cs
@@ -1,10 +1,8 @@
-﻿using System;
+﻿using B2Net.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using B2Net.Http;
-using B2Net.Models;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace B2Net.Tests {
 	[TestClass]
@@ -12,20 +10,20 @@ namespace B2Net.Tests {
 		private B2Bucket TestBucket = new B2Bucket();
 		private B2Client Client = null;
 		private List<B2File> FilesToDelete = new List<B2File>();
-	    private string BucketName = "";
+		private string BucketName = "";
 
 #if NETFULL
-	    private string FilePath => Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "../../../");
+		private string FilePath => Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "../../../");
 #else
         private string FilePath => Path.Combine(System.AppContext.BaseDirectory, "../../../");
 #endif
 
-        [TestInitialize]
+		[TestInitialize]
 		public void Initialize() {
 			Client = new B2Client(Options.AccountId, Options.ApplicationKey);
-            BucketName = $"B2NETTestingBucket-{Path.GetRandomFileName().Replace(".", "").Substring(0, 6)}";
+			BucketName = $"B2NETTestingBucket-{Path.GetRandomFileName().Replace(".", "").Substring(0, 6)}";
 
-            var buckets = Client.Buckets.GetList().Result;
+			var buckets = Client.Buckets.GetList().Result;
 			B2Bucket existingBucket = null;
 			foreach (B2Bucket b2Bucket in buckets) {
 				if (b2Bucket.BucketName == BucketName) {
@@ -35,104 +33,105 @@ namespace B2Net.Tests {
 
 			if (existingBucket != null) {
 				TestBucket = existingBucket;
-			} else {
+			}
+			else {
 				TestBucket = Client.Buckets.Create(BucketName, BucketTypes.allPrivate).Result;
 			}
-	    }
+		}
 
-	    [TestMethod]
-	    public void GetListTest() {
-	        var fileName = "B2Test.txt";
-	        var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-	        var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
-	        // Clean up.
-	        FilesToDelete.Add(file);
+		[TestMethod]
+		public void GetListTest() {
+			var fileName = "B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
+			// Clean up.
+			FilesToDelete.Add(file);
 
-	        var list = Client.Files.GetList(bucketId: TestBucket.BucketId).Result.Files;
+			var list = Client.Files.GetList(bucketId: TestBucket.BucketId).Result.Files;
 
-	        Assert.AreEqual(1, list.Count, list.Count + " files found.");
-	    }
+			Assert.AreEqual(1, list.Count, list.Count + " files found.");
+		}
 
-	    [TestMethod]
-	    public void GetListWithPrefixTest() {
-	        var fileName = "B2Test.txt";
-	        var fileNameWithFolder = "test/B2Test.txt";
-	        var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-	        var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
-	        var fileFolder = Client.Files.Upload(fileData, fileNameWithFolder, TestBucket.BucketId).Result;
-	        // Clean up.
-	        FilesToDelete.Add(file);
-	        FilesToDelete.Add(fileFolder);
+		[TestMethod]
+		public void GetListWithPrefixTest() {
+			var fileName = "B2Test.txt";
+			var fileNameWithFolder = "test/B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
+			var fileFolder = Client.Files.Upload(fileData, fileNameWithFolder, TestBucket.BucketId).Result;
+			// Clean up.
+			FilesToDelete.Add(file);
+			FilesToDelete.Add(fileFolder);
 
-	        var list = Client.Files.GetListWithPrefixOrDemiliter(bucketId: TestBucket.BucketId, prefix: "test").Result.Files;
+			var list = Client.Files.GetListWithPrefixOrDemiliter(bucketId: TestBucket.BucketId, prefix: "test").Result.Files;
 
-	        Assert.AreEqual(1, list.Count, list.Count + " files found.");
-	    }
+			Assert.AreEqual(1, list.Count, list.Count + " files found.");
+		}
 
-	    [TestMethod]
-	    public void GetListWithPrefixAndDelimiterTest() {
-	        var fileName = "B2Test.txt";
-	        var fileNameWithFolder = "test/B2Test.txt";
-	        var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-	        var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
-	        var fileFolder = Client.Files.Upload(fileData, fileNameWithFolder, TestBucket.BucketId).Result;
-	        // Clean up.
-	        FilesToDelete.Add(file);
-	        FilesToDelete.Add(fileFolder);
+		[TestMethod]
+		public void GetListWithPrefixAndDelimiterTest() {
+			var fileName = "B2Test.txt";
+			var fileNameWithFolder = "test/B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
+			var fileFolder = Client.Files.Upload(fileData, fileNameWithFolder, TestBucket.BucketId).Result;
+			// Clean up.
+			FilesToDelete.Add(file);
+			FilesToDelete.Add(fileFolder);
 
-	        var list = Client.Files.GetListWithPrefixOrDemiliter(bucketId: TestBucket.BucketId, prefix: "test", delimiter: "/").Result.Files;
+			var list = Client.Files.GetListWithPrefixOrDemiliter(bucketId: TestBucket.BucketId, prefix: "test", delimiter: "/").Result.Files;
 
-	        Assert.AreEqual(1, list.Count, list.Count + " files found.");
-	        Assert.AreEqual("test/", list.First().FileName, "File names to not match.");
-	    }
+			Assert.AreEqual(1, list.Count, list.Count + " files found.");
+			Assert.AreEqual("test/", list.First().FileName, "File names to not match.");
+		}
 
-	    [TestMethod]
-	    public void GetListWithDelimiterTest() {
-	        var fileName = "B2Test.txt";
-	        var fileNameWithFolder = "test/B2Test.txt";
-	        var fileNameWithFolder2 = "test2/B2Test.txt";
-            var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-	        var file = Client.Files.Upload(fileData, fileNameWithFolder2, TestBucket.BucketId).Result;
-	        var fileFolder = Client.Files.Upload(fileData, fileNameWithFolder, TestBucket.BucketId).Result;
-	        // Clean up.
-	        FilesToDelete.Add(file);
-	        FilesToDelete.Add(fileFolder);
+		[TestMethod]
+		public void GetListWithDelimiterTest() {
+			var fileName = "B2Test.txt";
+			var fileNameWithFolder = "test/B2Test.txt";
+			var fileNameWithFolder2 = "test2/B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			var file = Client.Files.Upload(fileData, fileNameWithFolder2, TestBucket.BucketId).Result;
+			var fileFolder = Client.Files.Upload(fileData, fileNameWithFolder, TestBucket.BucketId).Result;
+			// Clean up.
+			FilesToDelete.Add(file);
+			FilesToDelete.Add(fileFolder);
 
-	        var list = Client.Files.GetListWithPrefixOrDemiliter(bucketId: TestBucket.BucketId, delimiter: "/").Result.Files;
+			var list = Client.Files.GetListWithPrefixOrDemiliter(bucketId: TestBucket.BucketId, delimiter: "/").Result.Files;
 
-	        Assert.AreEqual(2, list.Count, list.Count + " files found.");
-	        Assert.IsTrue(list.All(f => f.Action == "folder"), "Not all list items were folders.");
-	    }
+			Assert.AreEqual(2, list.Count, list.Count + " files found.");
+			Assert.IsTrue(list.All(f => f.Action == "folder"), "Not all list items were folders.");
+		}
 
-        //[TestMethod]
-        //public void EmptyBucket() {
-        //	var list = Client.Files.GetList(bucketId: TestBucket.BucketId).Result.Files;
+		//[TestMethod]
+		//public void EmptyBucket() {
+		//	var list = Client.Files.GetList(bucketId: TestBucket.BucketId).Result.Files;
 
-        //	foreach (B2File b2File in list) {
-        //		var deletedFile = Client.Files.Delete(b2File.FileId, b2File.FileName).Result;
-        //	}
-        //}
+		//	foreach (B2File b2File in list) {
+		//		var deletedFile = Client.Files.Delete(b2File.FileId, b2File.FileName).Result;
+		//	}
+		//}
 
-        //[TestMethod]
-        //public void HideFileTest() {
-        //	var fileName = "B2Test.txt";
-        //	var fileData = File.ReadAllBytes(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName));
-        //	string hash = Utilities.GetSHA1Hash(fileData);
-        //	var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
-        //	// Clean up.
-        //	FilesToDelete.Add(file);
+		//[TestMethod]
+		//public void HideFileTest() {
+		//	var fileName = "B2Test.txt";
+		//	var fileData = File.ReadAllBytes(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName));
+		//	string hash = Utilities.GetSHA1Hash(fileData);
+		//	var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
+		//	// Clean up.
+		//	FilesToDelete.Add(file);
 
-        //	Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
+		//	Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
 
-        //          var hiddenFile = Client.Files.Hide(file.FileName, TestBucket.BucketId).Result;
+		//          var hiddenFile = Client.Files.Hide(file.FileName, TestBucket.BucketId).Result;
 
-        //          Assert.IsTrue(hiddenFile.Action == "hide");
+		//          Assert.IsTrue(hiddenFile.Action == "hide");
 
-        //          // Unhide the file so we can delete it later
-        //          hiddenFile = Client.Files.Hide(file.FileName, TestBucket.BucketId).Result;
-        //      }
+		//          // Unhide the file so we can delete it later
+		//          hiddenFile = Client.Files.Hide(file.FileName, TestBucket.BucketId).Result;
+		//      }
 
-        [TestMethod]
+		[TestMethod]
 		public void FileUploadTest() {
 			var fileName = "B2Test.txt";
 			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
@@ -145,98 +144,95 @@ namespace B2Net.Tests {
 			Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
 		}
 
-        [TestMethod]
-        public void FileUploadUsingUploadUrlTest() {
-            var fileName = "B2Test.txt";
-            var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-            string hash = Utilities.GetSHA1Hash(fileData);
+		[TestMethod]
+		public void FileUploadUsingUploadUrlTest() {
+			var fileName = "B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			string hash = Utilities.GetSHA1Hash(fileData);
 
-            var uploadUrl = Client.Files.GetUploadUrl(TestBucket.BucketId).Result;
+			var uploadUrl = Client.Files.GetUploadUrl(TestBucket.BucketId).Result;
 
-            var file = Client.Files.Upload(fileData, fileName, uploadUrl, true, TestBucket.BucketId).Result;
+			var file = Client.Files.Upload(fileData, fileName, uploadUrl, true, TestBucket.BucketId).Result;
 
-            // Clean up.
-            FilesToDelete.Add(file);
+			// Clean up.
+			FilesToDelete.Add(file);
 
-            Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
-        }
+			Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
+		}
 
-        //[TestMethod]
-        //public void FileUploadEncodingTest() {
-        //	var fileName = "B2 Test File.txt";
-        //	var fileData = File.ReadAllBytes(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName));
-        //	string hash = Utilities.GetSHA1Hash(fileData);
-        //	var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
+		//[TestMethod]
+		//public void FileUploadEncodingTest() {
+		//	var fileName = "B2 Test File.txt";
+		//	var fileData = File.ReadAllBytes(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName));
+		//	string hash = Utilities.GetSHA1Hash(fileData);
+		//	var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
 
-        //	// Clean up.
-        //	FilesToDelete.Add(file);
+		//	// Clean up.
+		//	FilesToDelete.Add(file);
 
-        //	Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
-        //}
+		//	Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
+		//}
 
-        [TestMethod]
-        public void FileUploadWithInfoTest()
-        {
-            var fileName = "B2Test.txt";
-            var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-            string hash = Utilities.GetSHA1Hash(fileData);
+		[TestMethod]
+		public void FileUploadWithInfoTest() {
+			var fileName = "B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			string hash = Utilities.GetSHA1Hash(fileData);
 
-            var fileInfo = new Dictionary<string, string>();
-            fileInfo.Add("FileInfoTest", "1234");
+			var fileInfo = new Dictionary<string, string>();
+			fileInfo.Add("FileInfoTest", "1234");
 
-            var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId, fileInfo).Result;
+			var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId, fileInfo).Result;
 
-            // Clean up.
-            FilesToDelete.Add(file);
+			// Clean up.
+			FilesToDelete.Add(file);
 
-            Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
-            Assert.AreEqual(1, file.FileInfo.Count, "File info count was off.");
-        }
+			Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
+			Assert.AreEqual(1, file.FileInfo.Count, "File info count was off.");
+		}
 
-        [TestMethod]
-        public void FileDownloadNameTest()
-        {
-            var fileName = "B2Test.txt";
-            var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-            string hash = Utilities.GetSHA1Hash(fileData);
-            var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
-            // Clean up.
-            FilesToDelete.Add(file);
+		[TestMethod]
+		public void FileDownloadNameTest() {
+			var fileName = "B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			string hash = Utilities.GetSHA1Hash(fileData);
+			var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
+			// Clean up.
+			FilesToDelete.Add(file);
 
-            Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
+			Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
 
-            // Test download
-            var download = Client.Files.DownloadByName(file.FileName, TestBucket.BucketName).Result;
-            var downloadHash = Utilities.GetSHA1Hash(download.FileData);
+			// Test download
+			var download = Client.Files.DownloadByName(file.FileName, TestBucket.BucketName).Result;
+			var downloadHash = Utilities.GetSHA1Hash(download.FileData);
 
-            Assert.AreEqual(hash, downloadHash);
-        }
+			Assert.AreEqual(hash, downloadHash);
+		}
 
-        [TestMethod]
-        public void FileDownloadWithInfoTest()
-        {
-            var fileName = "B2Test.txt";
-            var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-            string hash = Utilities.GetSHA1Hash(fileData);
+		[TestMethod]
+		public void FileDownloadWithInfoTest() {
+			var fileName = "B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			string hash = Utilities.GetSHA1Hash(fileData);
 
-            var fileInfo = new Dictionary<string, string>();
-            fileInfo.Add("FileInfoTest", "1234");
+			var fileInfo = new Dictionary<string, string>();
+			fileInfo.Add("FileInfoTest", "1234");
 
-            var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId, fileInfo).Result;
-            // Clean up.
-            FilesToDelete.Add(file);
+			var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId, fileInfo).Result;
+			// Clean up.
+			FilesToDelete.Add(file);
 
-            Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
+			Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
 
-            // Test download
-            var download = Client.Files.DownloadById(file.FileId).Result;
-            var downloadHash = Utilities.GetSHA1Hash(download.FileData);
+			// Test download
+			var download = Client.Files.DownloadById(file.FileId).Result;
+			var downloadHash = Utilities.GetSHA1Hash(download.FileData);
 
-            Assert.AreEqual(hash, downloadHash);
-            Assert.AreEqual(1, download.FileInfo.Count);
-        }
+			Assert.AreEqual(hash, downloadHash);
+			Assert.AreEqual(1, download.FileInfo.Count);
+		}
 
-        [TestMethod]
+		[TestMethod]
 		public void FileDownloadIdTest() {
 			var fileName = "B2Test.txt";
 			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
@@ -291,10 +287,10 @@ namespace B2Net.Tests {
 			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
 			string hash = Utilities.GetSHA1Hash(fileData);
 
-            var fileInfo = new Dictionary<string, string>();
-            fileInfo.Add("FileInfoTest", "1234");
+			var fileInfo = new Dictionary<string, string>();
+			fileInfo.Add("FileInfoTest", "1234");
 
-            var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId, fileInfo).Result;
+			var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId, fileInfo).Result;
 			// Clean up.
 			FilesToDelete.Add(file);
 
@@ -302,14 +298,14 @@ namespace B2Net.Tests {
 
 			var info = Client.Files.GetInfo(file.FileId).Result;
 
-            Assert.AreEqual(file.UploadTimestamp, info.UploadTimestamp);
-            Assert.AreEqual(1, info.FileInfo.Count);
-        }
+			Assert.AreEqual(file.UploadTimestamp, info.UploadTimestamp);
+			Assert.AreEqual(1, info.FileInfo.Count);
+		}
 
 		[TestMethod]
 		public void GetDownloadAuthorizationTest() {
 			var downloadAuth = Client.Files.GetDownloadAuthorization("Test", 120, TestBucket.BucketId).Result;
-			
+
 			Assert.AreEqual("Test", downloadAuth.FileNamePrefix, "File prefixes were not the same.");
 		}
 

--- a/tests/LargeFileTests.cs
+++ b/tests/LargeFileTests.cs
@@ -1,12 +1,10 @@
-﻿using System;
+﻿using B2Net.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using B2Net.Http;
-using B2Net.Models;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace B2Net.Tests {
 	[TestClass]
@@ -14,19 +12,19 @@ namespace B2Net.Tests {
 		private B2Bucket TestBucket = new B2Bucket();
 		private B2Client Client = null;
 		private List<B2File> FilesToDelete = new List<B2File>();
-	    private string BucketName = "";
+		private string BucketName = "";
 
 #if NETFULL
-	    private string FilePath => Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "../../../");
+		private string FilePath => Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "../../../");
 #else
         private string FilePath => Path.Combine(System.AppContext.BaseDirectory, "../../../");
 #endif
 
-        [TestInitialize]
+		[TestInitialize]
 		public void Initialize() {
 			Client = new B2Client(B2Client.Authorize(Options));
-            BucketName = $"B2NETTestingBucket-{Path.GetRandomFileName().Replace(".", "").Substring(0, 6)}";
-            var buckets = Client.Buckets.GetList().Result;
+			BucketName = $"B2NETTestingBucket-{Path.GetRandomFileName().Replace(".", "").Substring(0, 6)}";
+			var buckets = Client.Buckets.GetList().Result;
 			B2Bucket existingBucket = null;
 			foreach (B2Bucket b2Bucket in buckets) {
 				if (b2Bucket.BucketName == BucketName) {
@@ -36,197 +34,203 @@ namespace B2Net.Tests {
 
 			if (existingBucket != null) {
 				TestBucket = existingBucket;
-			} else {
+			}
+			else {
 				TestBucket = Client.Buckets.Create(BucketName, BucketTypes.allPrivate).Result;
 			}
 		}
-        
-        // THIS TEST DOES NOT PROPERLY CLEAN UP after an exception.
+
+		// THIS TEST DOES NOT PROPERLY CLEAN UP after an exception.
 		[TestMethod]
 		public void LargeFileUploadTest() {
 			var fileName = "B2LargeFileTest.txt";
 			FileStream fileStream = File.OpenRead(Path.Combine(FilePath, fileName));
-            var stream = new StreamReader(fileStream);
-		    char[] c = null;
-            List<byte[]> parts = new List<byte[]>();
-		    var shas = new List<string>();
+			var stream = new StreamReader(fileStream);
+			char[] c = null;
+			List<byte[]> parts = new List<byte[]>();
+			var shas = new List<string>();
 
-		    while (stream.Peek() >= 0) {
-		        c = new char[1024 * (5 * 1024)];
-		        stream.Read(c, 0, c.Length);
+			while (stream.Peek() >= 0) {
+				c = new char[1024 * (5 * 1024)];
+				stream.Read(c, 0, c.Length);
 
-		        parts.Add(Encoding.UTF8.GetBytes(c));
-            }
+				parts.Add(Encoding.UTF8.GetBytes(c));
+			}
 
-		    foreach (var part in parts) {
-		        string hash = Utilities.GetSHA1Hash(part);
-                shas.Add(hash);
-            }
+			foreach (var part in parts) {
+				string hash = Utilities.GetSHA1Hash(part);
+				shas.Add(hash);
+			}
 
-		    B2File start = null;
-		    B2File finish = null;
-            try {
-		        start = Client.LargeFiles.StartLargeFile(fileName, "", TestBucket.BucketId).Result;
+			B2File start = null;
+			B2File finish = null;
+			try {
+				start = Client.LargeFiles.StartLargeFile(fileName, "", TestBucket.BucketId).Result;
 
-		        for (int i = 0; i < parts.Count; i++) {
-		            var uploadUrl = Client.LargeFiles.GetUploadPartUrl(start.FileId).Result;
-		            var part = Client.LargeFiles.UploadPart(parts[i], i + 1, uploadUrl).Result;
-		        }
+				for (int i = 0; i < parts.Count; i++) {
+					var uploadUrl = Client.LargeFiles.GetUploadPartUrl(start.FileId).Result;
+					var part = Client.LargeFiles.UploadPart(parts[i], i + 1, uploadUrl).Result;
+				}
 
-		        finish = Client.LargeFiles.FinishLargeFile(start.FileId, shas.ToArray()).Result;
-		    }
-		    catch (Exception e) {
-		        Console.WriteLine(e);
-		        throw;
-		    }
-		    finally {
-		        // Clean up.
-		        FilesToDelete.Add(start);
-            }
+				finish = Client.LargeFiles.FinishLargeFile(start.FileId, shas.ToArray()).Result;
+			}
+			catch (Exception e) {
+				Console.WriteLine(e);
+				throw;
+			}
+			finally {
+				// Clean up.
+				FilesToDelete.Add(start);
+			}
 
-            
+
 			Assert.AreEqual(start.FileId, finish.FileId, "File Ids did not match.");
 		}
 
-	    [TestMethod]
-	    public void LargeFileUploadIncompleteGetPartsTest() {
-	        var fileName = "B2LargeFileTest.txt";
-	        FileStream fileStream = File.OpenRead(Path.Combine(FilePath, fileName));
-	        var stream = new StreamReader(fileStream);
-	        char[] c = null;
-	        List<byte[]> parts = new List<byte[]>();
-	        var shas = new List<string>();
+		[TestMethod]
+		public void LargeFileUploadIncompleteGetPartsTest() {
+			var fileName = "B2LargeFileTest.txt";
+			FileStream fileStream = File.OpenRead(Path.Combine(FilePath, fileName));
+			var stream = new StreamReader(fileStream);
+			char[] c = null;
+			List<byte[]> parts = new List<byte[]>();
+			var shas = new List<string>();
 
-	        var listParts = new B2LargeFileParts();
+			var listParts = new B2LargeFileParts();
 
-	        while (stream.Peek() >= 0) {
-	            c = new char[1024 * (5 * 1024)];
-	            stream.Read(c, 0, c.Length);
+			while (stream.Peek() >= 0) {
+				c = new char[1024 * (5 * 1024)];
+				stream.Read(c, 0, c.Length);
 
-	            parts.Add(Encoding.UTF8.GetBytes(c));
-	        }
+				parts.Add(Encoding.UTF8.GetBytes(c));
+			}
 
-	        foreach (var part in parts.Take(2)) {
-	            string hash = Utilities.GetSHA1Hash(part);
-	            shas.Add(hash);
-	        }
+			foreach (var part in parts.Take(2)) {
+				string hash = Utilities.GetSHA1Hash(part);
+				shas.Add(hash);
+			}
 
-	        B2File start = null;
-	        B2File finish = null;
-	        try {
-	            start = Client.LargeFiles.StartLargeFile(fileName, "", TestBucket.BucketId).Result;
+			B2File start = null;
+			B2File finish = null;
+			try {
+				start = Client.LargeFiles.StartLargeFile(fileName, "", TestBucket.BucketId).Result;
 
-	            for (int i = 0; i < 2; i++) {
-	                var uploadUrl = Client.LargeFiles.GetUploadPartUrl(start.FileId).Result;
-	                var part = Client.LargeFiles.UploadPart(parts[i], i + 1, uploadUrl).Result;
-	            }
+				for (int i = 0; i < 2; i++) {
+					var uploadUrl = Client.LargeFiles.GetUploadPartUrl(start.FileId).Result;
+					var part = Client.LargeFiles.UploadPart(parts[i], i + 1, uploadUrl).Result;
+				}
 
-                // Now we can list parts and get a result
-	            listParts = Client.LargeFiles.ListPartsForIncompleteFile(start.FileId, 1, 100).Result;
-	        } catch (Exception e) {
-	            Console.WriteLine(e);
-	            throw;
-	        } finally {
-	            // Clean up.
-	            FilesToDelete.Add(start);
-	        }
+				// Now we can list parts and get a result
+				listParts = Client.LargeFiles.ListPartsForIncompleteFile(start.FileId, 1, 100).Result;
+			}
+			catch (Exception e) {
+				Console.WriteLine(e);
+				throw;
+			}
+			finally {
+				// Clean up.
+				FilesToDelete.Add(start);
+			}
 
-	        Assert.AreEqual(2, listParts.Parts.Count, "List of parts did not return expected amount of parts.");
-	    }
+			Assert.AreEqual(2, listParts.Parts.Count, "List of parts did not return expected amount of parts.");
+		}
 
-	    [TestMethod]
-	    public void LargeFileCancelTest() {
-	        var fileName = "B2LargeFileTest.txt";
-	        FileStream fileStream = File.OpenRead(Path.Combine(FilePath, fileName));
-	        var stream = new StreamReader(fileStream);
-	        char[] c = null;
-	        List<byte[]> parts = new List<byte[]>();
-	        var shas = new List<string>();
+		[TestMethod]
+		public void LargeFileCancelTest() {
+			var fileName = "B2LargeFileTest.txt";
+			FileStream fileStream = File.OpenRead(Path.Combine(FilePath, fileName));
+			var stream = new StreamReader(fileStream);
+			char[] c = null;
+			List<byte[]> parts = new List<byte[]>();
+			var shas = new List<string>();
 
-	        var cancelledFile = new B2CancelledFile();
+			var cancelledFile = new B2CancelledFile();
 
-	        while (stream.Peek() >= 0) {
-	            c = new char[1024 * (5 * 1024)];
-	            stream.Read(c, 0, c.Length);
+			while (stream.Peek() >= 0) {
+				c = new char[1024 * (5 * 1024)];
+				stream.Read(c, 0, c.Length);
 
-	            parts.Add(Encoding.UTF8.GetBytes(c));
-	        }
+				parts.Add(Encoding.UTF8.GetBytes(c));
+			}
 
-	        foreach (var part in parts.Take(2)) {
-	            string hash = Utilities.GetSHA1Hash(part);
-	            shas.Add(hash);
-	        }
+			foreach (var part in parts.Take(2)) {
+				string hash = Utilities.GetSHA1Hash(part);
+				shas.Add(hash);
+			}
 
-	        B2File start = null;
-	        B2File finish = null;
-	        try {
-	            start = Client.LargeFiles.StartLargeFile(fileName, "", TestBucket.BucketId).Result;
+			B2File start = null;
+			B2File finish = null;
+			try {
+				start = Client.LargeFiles.StartLargeFile(fileName, "", TestBucket.BucketId).Result;
 
-	            for (int i = 0; i < 2; i++) {
-	                var uploadUrl = Client.LargeFiles.GetUploadPartUrl(start.FileId).Result;
-	                var part = Client.LargeFiles.UploadPart(parts[i], i + 1, uploadUrl).Result;
-	            }
+				for (int i = 0; i < 2; i++) {
+					var uploadUrl = Client.LargeFiles.GetUploadPartUrl(start.FileId).Result;
+					var part = Client.LargeFiles.UploadPart(parts[i], i + 1, uploadUrl).Result;
+				}
 
-	            // Now we can list parts and get a result
-	            cancelledFile = Client.LargeFiles.CancelLargeFile(start.FileId).Result;
-	        } catch (Exception e) {
-	            Console.WriteLine(e);
-	            throw;
-	        }
+				// Now we can list parts and get a result
+				cancelledFile = Client.LargeFiles.CancelLargeFile(start.FileId).Result;
+			}
+			catch (Exception e) {
+				Console.WriteLine(e);
+				throw;
+			}
 
-	        Assert.AreEqual(start.FileId, cancelledFile.FileId, "Started file and Cancelled file do not have the same id.");
-	    }
+			Assert.AreEqual(start.FileId, cancelledFile.FileId, "Started file and Cancelled file do not have the same id.");
+		}
 
-	    [TestMethod]
-	    public void LargeFileIncompleteListTest() {
-	        var fileName = "B2LargeFileTest.txt";
-	        FileStream fileStream = File.OpenRead(Path.Combine(FilePath, fileName));
-	        var stream = new StreamReader(fileStream);
-	        char[] c = null;
-	        List<byte[]> parts = new List<byte[]>();
-	        var shas = new List<string>();
+		[TestMethod]
+		public void LargeFileIncompleteListTest() {
+			var fileName = "B2LargeFileTest.txt";
+			FileStream fileStream = File.OpenRead(Path.Combine(FilePath, fileName));
+			var stream = new StreamReader(fileStream);
+			char[] c = null;
+			List<byte[]> parts = new List<byte[]>();
+			var shas = new List<string>();
 
-	        var fileList = new B2IncompleteLargeFiles();
+			var fileList = new B2IncompleteLargeFiles();
 
-	        while (stream.Peek() >= 0) {
-	            c = new char[1024 * (5 * 1024)];
-	            stream.Read(c, 0, c.Length);
+			while (stream.Peek() >= 0) {
+				c = new char[1024 * (5 * 1024)];
+				stream.Read(c, 0, c.Length);
 
-	            parts.Add(Encoding.UTF8.GetBytes(c));
-	        }
+				parts.Add(Encoding.UTF8.GetBytes(c));
+			}
 
-	        foreach (var part in parts.Take(2)) {
-	            string hash = Utilities.GetSHA1Hash(part);
-	            shas.Add(hash);
-	        }
+			foreach (var part in parts.Take(2)) {
+				string hash = Utilities.GetSHA1Hash(part);
+				shas.Add(hash);
+			}
 
-	        B2File start = null;
-	        B2File finish = null;
-	        try {
-	            start = Client.LargeFiles.StartLargeFile(fileName, "", TestBucket.BucketId).Result;
+			B2File start = null;
+			B2File finish = null;
+			try {
+				start = Client.LargeFiles.StartLargeFile(fileName, "", TestBucket.BucketId).Result;
 
-	            for (int i = 0; i < 2; i++) {
-	                var uploadUrl = Client.LargeFiles.GetUploadPartUrl(start.FileId).Result;
-	                var part = Client.LargeFiles.UploadPart(parts[i], i + 1, uploadUrl).Result;
-	            }
+				for (int i = 0; i < 2; i++) {
+					var uploadUrl = Client.LargeFiles.GetUploadPartUrl(start.FileId).Result;
+					var part = Client.LargeFiles.UploadPart(parts[i], i + 1, uploadUrl).Result;
+				}
 
-	            // Now we can list parts and get a result
-	            fileList = Client.LargeFiles.ListIncompleteFiles(TestBucket.BucketId).Result;
-	        } catch (Exception e) {
-	            Console.WriteLine(e);
-	            throw;
-	        } finally {
-	            var cancelledFile = Client.LargeFiles.CancelLargeFile(start.FileId).Result;
-	        }
+				// Now we can list parts and get a result
+				fileList = Client.LargeFiles.ListIncompleteFiles(TestBucket.BucketId).Result;
+			}
+			catch (Exception e) {
+				Console.WriteLine(e);
+				throw;
+			}
+			finally {
+				var cancelledFile = Client.LargeFiles.CancelLargeFile(start.FileId).Result;
+			}
 
-	        Assert.AreEqual(1, fileList.Files.Count, "Incomplete file list count does not match what we expected.");
-	    }
+			Assert.AreEqual(1, fileList.Files.Count, "Incomplete file list count does not match what we expected.");
+		}
 
-        [TestCleanup]
+		[TestCleanup]
 		public void Cleanup() {
 			foreach (B2File b2File in FilesToDelete) {
 				var deletedFile = Client.Files.Delete(b2File.FileId, b2File.FileName).Result;
-            }
+			}
 			var deletedBucket = Client.Buckets.Delete(TestBucket.BucketId).Result;
 		}
 	}

--- a/tests/PublicFileTests.cs
+++ b/tests/PublicFileTests.cs
@@ -1,10 +1,8 @@
-﻿using System;
+﻿using B2Net.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using B2Net.Http;
-using B2Net.Models;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace B2Net.Tests {
 	[TestClass]
@@ -12,15 +10,15 @@ namespace B2Net.Tests {
 		private B2Bucket TestBucket = new B2Bucket();
 		private B2Client Client = null;
 		private List<B2File> FilesToDelete = new List<B2File>();
-	    private string BucketName = "B2NETTestingBucketPublic";
+		private string BucketName = "B2NETTestingBucketPublic";
 
 #if NETFULL
-	    private string FilePath => Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "../../../");
+		private string FilePath => Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "../../../");
 #else
         private string FilePath => Path.Combine(System.AppContext.BaseDirectory, "../../../");
 #endif
 
-        [TestInitialize]
+		[TestInitialize]
 		public void Initialize() {
 			Client = new B2Client(Options);
 			Options = Client.Authorize().Result;
@@ -35,34 +33,34 @@ namespace B2Net.Tests {
 
 			if (existingBucket != null) {
 				TestBucket = existingBucket;
-			} else {
+			}
+			else {
 				TestBucket = Client.Buckets.Create(BucketName, BucketTypes.allPublic).Result;
 			}
 		}
 
-        [TestMethod]
-        public void FileGetFriendlyUrlTest()
-        {
-            var fileName = "B2Test.txt";
-            var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
-            string hash = Utilities.GetSHA1Hash(fileData);
-            var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
-            // Clean up.
-            FilesToDelete.Add(file);
+		[TestMethod]
+		public void FileGetFriendlyUrlTest() {
+			var fileName = "B2Test.txt";
+			var fileData = File.ReadAllBytes(Path.Combine(FilePath, fileName));
+			string hash = Utilities.GetSHA1Hash(fileData);
+			var file = Client.Files.Upload(fileData, fileName, TestBucket.BucketId).Result;
+			// Clean up.
+			FilesToDelete.Add(file);
 
-            Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
+			Assert.AreEqual(hash, file.ContentSHA1, "File hashes did not match.");
 
-            // Get url
-            var friendlyUrl = Client.Files.GetFriendlyDownloadUrl(fileName, TestBucket.BucketName);
+			// Get url
+			var friendlyUrl = Client.Files.GetFriendlyDownloadUrl(fileName, TestBucket.BucketName);
 
-            // Test download
-            var client = new HttpClient();
-            var friendFile = client.GetAsync(friendlyUrl).Result;
-            var ffileData = friendFile.Content.ReadAsByteArrayAsync().Result;
-            var downloadHash = Utilities.GetSHA1Hash(ffileData);
+			// Test download
+			var client = new HttpClient();
+			var friendFile = client.GetAsync(friendlyUrl).Result;
+			var ffileData = friendFile.Content.ReadAsByteArrayAsync().Result;
+			var downloadHash = Utilities.GetSHA1Hash(ffileData);
 
-            Assert.AreEqual(hash, downloadHash);
-        }
+			Assert.AreEqual(hash, downloadHash);
+		}
 
 		[TestCleanup]
 		public void Cleanup() {


### PR DESCRIPTION
I've reformatted all the code using .editorconfig settings for consistency.

All files are now tabs, with a default width of 4.

I also had to specify `csharp_new_line_before_open_brace = none` as my default was different to the majority of the code.