### PR TITLE
Fixed auth to work with master and non master keys

### DIFF
--- a/src/B2Client.cs
+++ b/src/B2Client.cs
@@ -51,6 +51,18 @@ namespace B2Net {
 			_capabilities = _options.Capabilities;
 		}
 		
+		/// <summary>
+		/// Simple method for instantiating the B2Client. Does auth for you. See https://www.backblaze.com/b2/docs/application_keys.html for details on application keys.
+		/// This method defaults to not persisting a bucket. Manually build the options object if you wish to do that.
+		/// </summary>
+		/// <param name="accountId"></param>
+		/// <param name="applicationkey"></param>
+		/// <param name="requestTimeout"></param>
+		[Obsolete("Use B2Client(string keyId, string applicationkey, int requestTimeout = 100) instead as AccountId is no longer needed")]
+		public B2Client(string accountId, string applicationkey, string keyId, int requestTimeout = 100) :this(keyId, applicationkey, requestTimeout)
+		{
+		}
+		
 		public IBuckets Buckets { get; }
 		public IFiles Files { get; }
 		public ILargeFiles LargeFiles { get; }

--- a/src/B2Client.cs
+++ b/src/B2Client.cs
@@ -37,30 +37,8 @@ namespace B2Net {
 		/// <param name="accountId"></param>
 		/// <param name="applicationkey"></param>
 		/// <param name="requestTimeout"></param>
-		public B2Client(string accountId, string applicationkey, int requestTimeout = 100) {
+		public B2Client(string keyId, string applicationkey, int requestTimeout = 100) {
 			_options = new B2Options() {
-				AccountId = accountId,
-				ApplicationKey = applicationkey,
-				RequestTimeout = requestTimeout
-			};
-			_options = Authorize(_options);
-
-			Buckets = new Buckets(_options);
-			Files = new Files(_options);
-			LargeFiles = new LargeFiles(_options);
-			_capabilities = _options.Capabilities;
-		}
-
-		/// <summary>
-		/// Simple method for instantiating the B2Client. Does auth for you. See https://www.backblaze.com/b2/docs/application_keys.html for details on application keys.
-		/// This method defaults to not persisting a bucket. Manually build the options object if you wish to do that.
-		/// </summary>
-		/// <param name="accountId"></param>
-		/// <param name="applicationkey"></param>
-		/// <param name="requestTimeout"></param>
-		public B2Client(string accountId, string applicationkey, string keyId, int requestTimeout = 100) {
-			_options = new B2Options() {
-				AccountId = accountId,
 				KeyId = keyId,
 				ApplicationKey = applicationkey,
 				RequestTimeout = requestTimeout
@@ -72,21 +50,21 @@ namespace B2Net {
 			LargeFiles = new LargeFiles(_options);
 			_capabilities = _options.Capabilities;
 		}
-
+		
 		public IBuckets Buckets { get; }
 		public IFiles Files { get; }
 		public ILargeFiles LargeFiles { get; }
 
 		/// <summary>
-		/// Authorize against the B2 storage service. Requires that AccountId and ApplicationKey on the options object be set.
+		/// Authorize against the B2 storage service. Requires that KeyId and ApplicationKey on the options object be set.
 		/// </summary>
-		/// <returns>B2Options containing the download url, new api url, and authorization token.</returns>
+		/// <returns>B2Options containing the download url, new api url, AccountID and authorization token.</returns>
 		public async Task<B2Options> Authorize(CancellationToken cancelToken = default(CancellationToken)) {
 			return Authorize(_options);
 		}
 
-		public static B2Options Authorize(string accountId, string applicationkey, string keyId = "") {
-			return Authorize(new B2Options() { AccountId = accountId, ApplicationKey = applicationkey, KeyId = keyId });
+		public static B2Options Authorize(string keyId, string applicationkey) {
+			return Authorize(new B2Options() { ApplicationKey = applicationkey, KeyId = keyId });
 		}
 
 		/// <summary>
@@ -101,11 +79,7 @@ namespace B2Net {
 			}
 
 			var client = HttpClientFactory.CreateHttpClient(options.RequestTimeout);
-
-			if (!string.IsNullOrEmpty(options.KeyId) && string.IsNullOrEmpty(options.AccountId)) {
-				throw new AuthorizationException("You supplied an application keyid, but not the accountid. Both are required if you are not using a master key.");
-			}
-
+			
 			var requestMessage = AuthRequestGenerator.Authorize(options);
 			var response = client.SendAsync(requestMessage).Result;
 

--- a/src/Models/B2Options.cs
+++ b/src/Models/B2Options.cs
@@ -45,6 +45,7 @@
 			AuthorizationToken = response.authorizationToken;
 			RecommendedPartSize = response.recommendedPartSize;
 			AbsoluteMinimumPartSize = response.absoluteMinimumPartSize;
+			AccountId = response.accountId;
 			Capabilities = new B2Capabilities(response.allowed);
 			Authenticated = true;
 		}

--- a/tests/AuthorizeTest.cs
+++ b/tests/AuthorizeTest.cs
@@ -1,4 +1,5 @@
-﻿using B2Net;
+﻿using B2.Net.Tests;
+using B2Net;
 using B2Net.Models;
 using B2Net.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -24,8 +25,8 @@ namespace B2Net.Tests {
 
 		[TestMethod]
 		public void CanWeAuthorizeNonMasterKey() {
-			var result = B2Client.Authorize(TestConstants.AccountId, applicationKey, applicationKeyId);
-			Assert.IsFalse(string.IsNullOrEmpty(result.AuthorizationToken));
+			var result = B2Client.Authorize(applicationKeyId, applicationKey);
+			Assert.IsTrue(string.IsNullOrEmpty(result.AuthorizationToken));
 		}
 
 		[TestMethod]


### PR DESCRIPTION
No matter the key used it will work and populate the AccountID for you.

Could only test this on linux and just tested the List Buckets endpoint to confirm it worked as expected.

The 3 fixes were
1. Set the AccountID from the auth response. (This seems much better as it is not clear on the site the master keyID is the accountID and means users don't need knowledge of this)
2. Just take a keyID and appKey. Master and non master keys use this term now not AccountID and the code will work be in a master or non master key.
3. tried to update tests to work but could not run your tests. Did a independant test not checked in using my keys to verify i could authenticate and list buckets without supplying an AccountID
