### PR TITLE
Readme Fix > Update a Bucket with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ var bucket = await client.Buckets.Update("BUCKETID", "BUCKETYPE");
 #### Update a Bucket with options
 ```csharp
 var client = new B2Client("KEYID", "APPLICATIONKEY");
-var bucket = await client.Buckets.Update("BUCKETID", new B2BucketOptions() {
+var bucket = await client.Buckets.Update(new B2BucketOptions() {
 	CacheControl = 300,
 	LifecycleRules = new List<B2BucketLifecycleRule>() {
 		new B2BucketLifecycleRule() {
@@ -165,7 +165,8 @@ var bucket = await client.Buckets.Update("BUCKETID", new B2BucketOptions() {
 			MaxAgeSeconds = 1200
 		}
 	},
-});
+}, "BUCKETID", );
+
 // { BucketId: "",
 //   BucketName: "",
 //   BucketType: "",

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ var bucket = await client.Buckets.Update(new B2BucketOptions() {
 			MaxAgeSeconds = 1200
 		}
 	},
-}, "BUCKETID", );
+}, "BUCKETID");
 
 // { BucketId: "",
 //   BucketName: "",


### PR DESCRIPTION
Readme Fix > Update a Bucket with options

Code parameters in wrong order. 

Should be: `client.Buckets.Update(options, bucketId)`

Not: `client.Buckets.Update(bucketId, options)`