### PR TITLE
Made HttpClient initialization more thread-safeish

### DIFF
--- a/src/Http/HttpClientFactory.cs
+++ b/src/Http/HttpClientFactory.cs
@@ -7,17 +7,19 @@ namespace B2Net.Http {
 		private static HttpClient _client;
 
 		public static HttpClient CreateHttpClient(int timeout) {
-			if (_client == null) {
+			var client = _client;
+			if (client == null) {
 				var handler = new HttpClientHandler() { AllowAutoRedirect = true };
 
-				_client = new HttpClient(handler);
+				client = new HttpClient(handler);
 
-				_client.Timeout = TimeSpan.FromSeconds(timeout);
+				client.Timeout = TimeSpan.FromSeconds(timeout);
 
-				_client.DefaultRequestHeaders.Accept.Clear();
-				_client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+				client.DefaultRequestHeaders.Accept.Clear();
+				client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+				_client = client;
 			}
-			return _client;
+			return client;
 		}
 	}
 }


### PR DESCRIPTION
While doing some multi-threaded batch processing using B2.NET I would sporadically get an Duplicate Key exception from the underlying System.Net.HttpClient during startup.

I traced it back to how the singleton HttpClient is being constructed.
If the stairs align just right it is currently possible that two threads try to add the system Accept request header at the same time (resulting in the previously mentioned exception).

I have added a simple fix in this pull request by privately creating and configuring the HttpClient before sharing it with the rest of the AppDomain.
